### PR TITLE
[feat] ✨: Add domain management tools and update documentation to ref…

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ For detailed transport mode documentation and client examples, refer to the conf
 
 ## 📚 Available Tools
 
-This MCP server provides **58 tools** organized into four main categories:
+This MCP server provides **67 tools** organized into five main categories:
 
 ### 🗂️ Project Management (6 tools)
 
@@ -362,6 +362,18 @@ This MCP server provides **58 tools** organized into four main categories:
 - `application-saveBuildType`, `application-saveEnvironment`, `application-saveDockerProvider`
 - `application-readAppMonitoring`, `application-readTraefikConfig`, `application-updateTraefikConfig`
 - `application-refreshToken`, `application-cleanQueues`
+
+### 🌐 Domain Management (9 tools)
+
+- `domain-byApplicationId` - List domains by application ID
+- `domain-byComposeId` - List domains by compose service ID
+- `domain-one` - Get domain by ID
+- `domain-create` - Create domain (application/compose/preview)
+- `domain-update` - Update domain configuration
+- `domain-delete` - Delete domain
+- `domain-validateDomain` - Validate domain DNS/target
+- `domain-generateDomain` - Suggest a domain for an app
+- `domain-canGenerateTraefikMeDomains` - Check Traefik.me availability on a server
 
 ### 🐘 PostgreSQL Database Management (13 tools)
 
@@ -390,7 +402,7 @@ For detailed schemas, parameters, and usage examples, see **[TOOLS.md](TOOLS.md)
 
 Built with **@modelcontextprotocol/sdk**, **TypeScript**, and **Zod** for type-safe schema validation:
 
-- **58 Tools** covering projects, applications, PostgreSQL, and MySQL management
+- **67 Tools** covering projects, applications, domains, PostgreSQL, and MySQL management
 - **Multiple Transports**: Stdio (default) and HTTP (Streamable HTTP + legacy SSE)
 - **Multiple Git Providers**: GitHub, GitLab, Bitbucket, Gitea, custom Git
 - **Robust Error Handling**: Centralized API client with retry logic

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -4,9 +4,10 @@ This document provides detailed information about all available tools in the Dok
 
 ## 📊 Overview
 
-- **Total Tools**: 58
+- **Total Tools**: 67
 - **Project Tools**: 6
 - **Application Tools**: 26
+- **Domain Tools**: 9
 - **PostgreSQL Tools**: 13
 - **MySQL Tools**: 13
 
@@ -480,6 +481,146 @@ All tools include semantic annotations (`readOnlyHint`, `destructiveHint`, `idem
   ```
 - **Annotations**: Destructive
 - **Required Fields**: `applicationId`
+
+## 🌐 Domain Management Tools
+
+These tools manage domains for applications, compose services, and preview deployments, including SSL/TLS, routing, validation, and automatic suggestions.
+
+### `domain-byApplicationId`
+
+- **Description**: Retrieves all domains associated with a specific application in Dokploy
+- **Input Schema**:
+  ```json
+  {
+    "applicationId": "string"
+  }
+  ```
+- **Annotations**: Read-only, Idempotent
+- **Required Fields**: `applicationId`
+
+### `domain-byComposeId`
+
+- **Description**: Retrieves all domains associated with a specific compose stack/service in Dokploy
+- **Input Schema**:
+  ```json
+  {
+    "composeId": "string"
+  }
+  ```
+- **Annotations**: Read-only, Idempotent
+- **Required Fields**: `composeId`
+
+### `domain-one`
+
+- **Description**: Retrieves a specific domain configuration by its ID in Dokploy
+- **Input Schema**:
+  ```json
+  {
+    "domainId": "string"
+  }
+  ```
+- **Annotations**: Read-only, Idempotent
+- **Required Fields**: `domainId`
+
+### `domain-create`
+
+- **Description**: Creates a new domain configuration (application, compose, or preview) with SSL options
+- **Input Schema**:
+  ```json
+  {
+    "host": "string",
+    "path": "string|null",
+    "port": "number|null",
+    "https": "boolean",
+    "applicationId": "string|null",
+    "certificateType": "letsencrypt|none|custom",
+    "customCertResolver": "string|null",
+    "composeId": "string|null",
+    "serviceName": "string|null",
+    "domainType": "compose|application|preview|null",
+    "previewDeploymentId": "string|null",
+    "internalPath": "string|null",
+    "stripPath": "boolean"
+  }
+  ```
+- **Annotations**: Non-destructive, Non-idempotent
+- **Required Fields**: `host`, `https`, `certificateType`, `stripPath`
+- **Optional Fields**: `path`, `port`, `applicationId`, `customCertResolver`, `composeId`, `serviceName`, `domainType`, `previewDeploymentId`, `internalPath`
+
+### `domain-update`
+
+- **Description**: Updates an existing domain configuration (host, SSL, routing, service associations)
+- **Input Schema**:
+  ```json
+  {
+    "domainId": "string",
+    "host": "string",
+    "path": "string|null",
+    "port": "number|null",
+    "https": "boolean",
+    "certificateType": "letsencrypt|none|custom",
+    "customCertResolver": "string|null",
+    "serviceName": "string|null",
+    "domainType": "compose|application|preview|null",
+    "internalPath": "string|null",
+    "stripPath": "boolean"
+  }
+  ```
+- **Annotations**: Non-destructive, Idempotent
+- **Required Fields**: `domainId`, `host`, `https`, `certificateType`, `stripPath`
+- **Optional Fields**: `path`, `port`, `customCertResolver`, `serviceName`, `domainType`, `internalPath`
+
+### `domain-delete`
+
+- **Description**: Deletes a domain configuration by ID
+- **Input Schema**:
+  ```json
+  {
+    "domainId": "string"
+  }
+  ```
+- **Annotations**: Destructive, Non-idempotent
+- **Required Fields**: `domainId`
+
+### `domain-validateDomain`
+
+- **Description**: Validates if a domain is correctly configured, optionally against a specific server IP
+- **Input Schema**:
+  ```json
+  {
+    "domain": "string",
+    "serverIp": "string(optional)"
+  }
+  ```
+- **Annotations**: Read-only, Idempotent
+- **Required Fields**: `domain`
+- **Optional Fields**: `serverIp`
+
+### `domain-generateDomain`
+
+- **Description**: Generates a suggested domain for an application name, optionally scoped to a server
+- **Input Schema**:
+  ```json
+  {
+    "appName": "string",
+    "serverId": "string(optional)"
+  }
+  ```
+- **Annotations**: Read-only, Idempotent
+- **Required Fields**: `appName`
+- **Optional Fields**: `serverId`
+
+### `domain-canGenerateTraefikMeDomains`
+
+- **Description**: Checks whether Traefik.me domains can be generated for a specific server
+- **Input Schema**:
+  ```json
+  {
+    "serverId": "string"
+  }
+  ```
+- **Annotations**: Read-only, Idempotent
+- **Required Fields**: `serverId`
 
 ## 🐘 PostgreSQL Database Management Tools
 

--- a/src/mcp/tools/domain/domainByApplicationId.ts
+++ b/src/mcp/tools/domain/domainByApplicationId.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import apiClient from "../../../utils/apiClient.js";
+import { createTool } from "../toolFactory.js";
+import { ResponseFormatter } from "../../../utils/responseFormatter.js";
+
+export const domainByApplicationId = createTool({
+  name: "domain-byApplicationId",
+  description:
+    "Retrieves all domains associated with a specific application in Dokploy. Returns a list of domain configurations including SSL settings, paths, and routing information.",
+  schema: z.object({
+    applicationId: z
+      .string()
+      .min(1)
+      .describe("The ID of the application to retrieve domains for."),
+  }),
+  annotations: {
+    title: "Get Domains by Application ID",
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  handler: async (input) => {
+    const response = await apiClient.get("/domain.byApplicationId", {
+      params: {
+        applicationId: input.applicationId,
+      },
+    });
+
+    return ResponseFormatter.success(
+      `Successfully retrieved domains for application ${input.applicationId}`,
+      response.data
+    );
+  },
+});

--- a/src/mcp/tools/domain/domainByComposeId.ts
+++ b/src/mcp/tools/domain/domainByComposeId.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import apiClient from "../../../utils/apiClient.js";
+import { createTool } from "../toolFactory.js";
+import { ResponseFormatter } from "../../../utils/responseFormatter.js";
+
+export const domainByComposeId = createTool({
+  name: "domain-byComposeId",
+  description:
+    "Retrieves all domains associated with a specific compose stack/service in Dokploy. Returns a list of domain configurations including SSL settings, paths, and routing information.",
+  schema: z.object({
+    composeId: z
+      .string()
+      .min(1)
+      .describe("The ID of the compose service to retrieve domains for."),
+  }),
+  annotations: {
+    title: "Get Domains by Compose ID",
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  handler: async (input) => {
+    const response = await apiClient.get("/domain.byComposeId", {
+      params: {
+        composeId: input.composeId,
+      },
+    });
+
+    return ResponseFormatter.success(
+      `Successfully retrieved domains for compose ${input.composeId}`,
+      response.data
+    );
+  },
+});

--- a/src/mcp/tools/domain/domainCanGenerateTraefikMeDomains.ts
+++ b/src/mcp/tools/domain/domainCanGenerateTraefikMeDomains.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import apiClient from "../../../utils/apiClient.js";
+import { createTool } from "../toolFactory.js";
+import { ResponseFormatter } from "../../../utils/responseFormatter.js";
+
+export const domainCanGenerateTraefikMeDomains = createTool({
+  name: "domain-canGenerateTraefikMeDomains",
+  description:
+    "Checks whether Traefik.me domains can be generated for a specific server in Dokploy.",
+  schema: z.object({
+    serverId: z
+      .string()
+      .min(1)
+      .describe(
+        "The server ID to verify Traefik.me domain generation support for."
+      ),
+  }),
+  annotations: {
+    title: "Can Generate Traefik.me Domains",
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  handler: async (input) => {
+    const response = await apiClient.get(
+      "/domain.canGenerateTraefikMeDomains",
+      {
+        params: {
+          serverId: input.serverId,
+        },
+      }
+    );
+
+    return ResponseFormatter.success(
+      `Retrieved Traefik.me domain generation availability for server ${input.serverId}`,
+      response.data
+    );
+  },
+});

--- a/src/mcp/tools/domain/domainCreate.ts
+++ b/src/mcp/tools/domain/domainCreate.ts
@@ -1,0 +1,107 @@
+import { z } from "zod";
+import apiClient from "../../../utils/apiClient.js";
+import { createTool } from "../toolFactory.js";
+import { ResponseFormatter } from "../../../utils/responseFormatter.js";
+
+export const domainCreate = createTool({
+  name: "domain-create",
+  description:
+    "Creates a new domain configuration in Dokploy. Domains can be configured for applications, compose services, or preview deployments with SSL/TLS certificate options.",
+  schema: z.object({
+    host: z
+      .string()
+      .min(1)
+      .describe(
+        "The domain host (e.g., example.com or subdomain.example.com)."
+      ),
+    path: z
+      .string()
+      .min(1)
+      .nullable()
+      .optional()
+      .describe(
+        "Optional path for the domain (e.g., /api). Used for path-based routing."
+      ),
+    port: z
+      .number()
+      .min(1)
+      .max(65535)
+      .nullable()
+      .optional()
+      .describe(
+        "The port number for the service (1-65535). If not specified, defaults will be used."
+      ),
+    https: z.boolean().describe("Whether to enable HTTPS for this domain."),
+    applicationId: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "The ID of the application to associate this domain with. Required if domainType is 'application'."
+      ),
+    certificateType: z
+      .enum(["letsencrypt", "none", "custom"])
+      .describe(
+        "The type of SSL certificate: 'letsencrypt' for automatic Let's Encrypt certificates, 'none' for no SSL, or 'custom' for custom certificates."
+      ),
+    customCertResolver: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Custom certificate resolver name. Required when certificateType is 'custom'."
+      ),
+    composeId: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "The ID of the compose service to associate this domain with. Required if domainType is 'compose'."
+      ),
+    serviceName: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "The name of the service within the compose stack. Used with composeId."
+      ),
+    domainType: z
+      .enum(["compose", "application", "preview"])
+      .nullable()
+      .optional()
+      .describe(
+        "The type of domain: 'application' for app domains, 'compose' for compose services, or 'preview' for preview deployments."
+      ),
+    previewDeploymentId: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "The ID of the preview deployment. Required if domainType is 'preview'."
+      ),
+    internalPath: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("Internal path for routing within the container/service."),
+    stripPath: z
+      .boolean()
+      .describe(
+        "Whether to strip the path prefix when forwarding requests to the backend service."
+      ),
+  }),
+  annotations: {
+    title: "Create Domain",
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  handler: async (input) => {
+    const response = await apiClient.post("/domain.create", input);
+
+    return ResponseFormatter.success(
+      `Domain "${input.host}" created successfully with ${input.certificateType} certificate type`,
+      response.data
+    );
+  },
+});

--- a/src/mcp/tools/domain/domainDelete.ts
+++ b/src/mcp/tools/domain/domainDelete.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import apiClient from "../../../utils/apiClient.js";
+import { createTool } from "../toolFactory.js";
+import { ResponseFormatter } from "../../../utils/responseFormatter.js";
+
+export const domainDelete = createTool({
+  name: "domain-delete",
+  description: "Deletes an existing domain configuration in Dokploy by its ID.",
+  schema: z.object({
+    domainId: z.string().min(1).describe("The ID of the domain to delete."),
+  }),
+  annotations: {
+    title: "Delete Domain",
+    destructiveHint: true,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
+  handler: async (input) => {
+    const response = await apiClient.post("/domain.delete", {
+      domainId: input.domainId,
+    });
+
+    return ResponseFormatter.success(
+      `Domain ${input.domainId} deleted successfully`,
+      response.data
+    );
+  },
+});

--- a/src/mcp/tools/domain/domainGenerateDomain.ts
+++ b/src/mcp/tools/domain/domainGenerateDomain.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import apiClient from "../../../utils/apiClient.js";
+import { createTool } from "../toolFactory.js";
+import { ResponseFormatter } from "../../../utils/responseFormatter.js";
+
+export const domainGenerateDomain = createTool({
+  name: "domain-generateDomain",
+  description:
+    "Generates a suggested domain for a given application name, optionally scoped to a server.",
+  schema: z.object({
+    appName: z
+      .string()
+      .min(1)
+      .describe("The application name to generate a domain for."),
+    serverId: z
+      .string()
+      .optional()
+      .describe("Optional server ID to use when generating the domain."),
+  }),
+  annotations: {
+    title: "Generate Domain",
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  handler: async (input) => {
+    const response = await apiClient.post("/domain.generateDomain", input);
+
+    return ResponseFormatter.success(
+      `Successfully generated domain for app \"${input.appName}\"`,
+      response.data
+    );
+  },
+});

--- a/src/mcp/tools/domain/domainOne.ts
+++ b/src/mcp/tools/domain/domainOne.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import apiClient from "../../../utils/apiClient.js";
+import { createTool } from "../toolFactory.js";
+import { ResponseFormatter } from "../../../utils/responseFormatter.js";
+
+export const domainOne = createTool({
+  name: "domain-one",
+  description:
+    "Retrieves a specific domain configuration by its ID in Dokploy.",
+  schema: z.object({
+    domainId: z.string().min(1).describe("The ID of the domain to retrieve."),
+  }),
+  annotations: {
+    title: "Get Domain by ID",
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  handler: async (input) => {
+    const response = await apiClient.get("/domain.one", {
+      params: { domainId: input.domainId },
+    });
+
+    return ResponseFormatter.success(
+      `Successfully retrieved domain ${input.domainId}`,
+      response.data
+    );
+  },
+});

--- a/src/mcp/tools/domain/domainUpdate.ts
+++ b/src/mcp/tools/domain/domainUpdate.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import apiClient from "../../../utils/apiClient.js";
+import { createTool } from "../toolFactory.js";
+import { ResponseFormatter } from "../../../utils/responseFormatter.js";
+
+export const domainUpdate = createTool({
+  name: "domain-update",
+  description:
+    "Updates an existing domain configuration in Dokploy. Allows modifying domain settings including host, SSL configuration, routing options, and service associations.",
+  schema: z.object({
+    host: z
+      .string()
+      .min(1)
+      .describe(
+        "The domain host (e.g., example.com or subdomain.example.com)."
+      ),
+    path: z
+      .string()
+      .min(1)
+      .nullable()
+      .optional()
+      .describe(
+        "Optional path for the domain (e.g., /api). Used for path-based routing."
+      ),
+    port: z
+      .number()
+      .min(1)
+      .max(65535)
+      .nullable()
+      .optional()
+      .describe(
+        "The port number for the service (1-65535). If not specified, defaults will be used."
+      ),
+    https: z.boolean().describe("Whether to enable HTTPS for this domain."),
+    certificateType: z
+      .enum(["letsencrypt", "none", "custom"])
+      .describe(
+        "The type of SSL certificate: 'letsencrypt' for automatic Let's Encrypt certificates, 'none' for no SSL, or 'custom' for custom certificates."
+      ),
+    customCertResolver: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "Custom certificate resolver name. Required when certificateType is 'custom'."
+      ),
+    serviceName: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "The name of the service within the compose stack. Used with composeId."
+      ),
+    domainType: z
+      .enum(["compose", "application", "preview"])
+      .nullable()
+      .optional()
+      .describe(
+        "The type of domain: 'application' for app domains, 'compose' for compose services, or 'preview' for preview deployments."
+      ),
+    internalPath: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("Internal path for routing within the container/service."),
+    stripPath: z
+      .boolean()
+      .describe(
+        "Whether to strip the path prefix when forwarding requests to the backend service."
+      ),
+    domainId: z.string().describe("The ID of the domain to update."),
+  }),
+  annotations: {
+    title: "Update Domain",
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  handler: async (input) => {
+    const response = await apiClient.post("/domain.update", input);
+
+    return ResponseFormatter.success(
+      `Domain "${input.host}" updated successfully`,
+      response.data
+    );
+  },
+});

--- a/src/mcp/tools/domain/domainValidateDomain.ts
+++ b/src/mcp/tools/domain/domainValidateDomain.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import apiClient from "../../../utils/apiClient.js";
+import { createTool } from "../toolFactory.js";
+import { ResponseFormatter } from "../../../utils/responseFormatter.js";
+
+export const domainValidateDomain = createTool({
+  name: "domain-validateDomain",
+  description:
+    "Validates if a domain is correctly configured, optionally against a specific server IP.",
+  schema: z.object({
+    domain: z
+      .string()
+      .min(1)
+      .describe("The domain name to validate (e.g., example.com)."),
+    serverIp: z
+      .string()
+      .optional()
+      .describe("Optional server IP to validate DNS resolution against."),
+  }),
+  annotations: {
+    title: "Validate Domain",
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  handler: async (input) => {
+    const response = await apiClient.post("/domain.validateDomain", input);
+
+    return ResponseFormatter.success(
+      `Validation result for domain "${input.domain}":`,
+      response.data
+    );
+  },
+});

--- a/src/mcp/tools/domain/index.ts
+++ b/src/mcp/tools/domain/index.ts
@@ -1,0 +1,9 @@
+export { domainCreate } from "./domainCreate.js";
+export { domainByApplicationId } from "./domainByApplicationId.js";
+export { domainByComposeId } from "./domainByComposeId.js";
+export { domainGenerateDomain } from "./domainGenerateDomain.js";
+export { domainCanGenerateTraefikMeDomains } from "./domainCanGenerateTraefikMeDomains.js";
+export { domainUpdate } from "./domainUpdate.js";
+export { domainOne } from "./domainOne.js";
+export { domainDelete } from "./domainDelete.js";
+export { domainValidateDomain } from "./domainValidateDomain.js";

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -1,4 +1,5 @@
 import * as applicationTools from "./application/index.js";
+import * as domainTools from "./domain/index.js";
 import * as mysqlTools from "./mysql/index.js";
 import * as postgresTools from "./postgres/index.js";
 import * as projectTools from "./project/index.js";
@@ -6,6 +7,7 @@ import * as projectTools from "./project/index.js";
 export const allTools = [
   ...Object.values(projectTools),
   ...Object.values(applicationTools),
+  ...Object.values(domainTools),
   ...Object.values(mysqlTools),
   ...Object.values(postgresTools),
 ];


### PR DESCRIPTION
This pull request introduces a comprehensive Domain Management toolset to the MCP server, expanding the platform's capabilities for managing domains associated with applications, compose services, and preview deployments. The update adds nine new tools for domain operations, updates documentation to reflect the new functionality, and integrates these tools into the overall system.

**Domain Management Feature Additions:**

* Added nine new domain management tools, including: list domains by application or compose ID, retrieve a domain by ID, create, update, and delete domains, validate domain configuration, generate suggested domains, and check Traefik.me domain support. (`src/mcp/tools/domain/domainByApplicationId.ts` [[1]](diffhunk://#diff-74e2bd806d456bcf30c1f6dac5f39d6e425d5a0ab7d6bf0b6a8622b268c150a4R1-R34) `src/mcp/tools/domain/domainByComposeId.ts` [[2]](diffhunk://#diff-8e3e8046a24a79b0f55c338643589b4cbd9b291ea95036f052a0ac9ca8c40e02R1-R34) `src/mcp/tools/domain/domainOne.ts` [[3]](diffhunk://#diff-014d249c6dfe2df9f8f61c2895d58c77a435008c8886325d4df1608a951e0830R1-R29) `src/mcp/tools/domain/domainCreate.ts` [[4]](diffhunk://#diff-e9c43deb9a4693dbb5a5a520c807079709ecb288bcd44b86321e0c146c8623c0R1-R107) `src/mcp/tools/domain/domainUpdate.ts` [[5]](diffhunk://#diff-4deb7424a95766eaa7a5a46a9c4bd3386ce01e133723afded9f0aa8c736e4b58R1-R87) `src/mcp/tools/domain/domainDelete.ts` [[6]](diffhunk://#diff-8505df3bf66478348bb5d9768b4ccafe3bb51cff8c7621f8673a4a8a454b52d0R1-R28) `src/mcp/tools/domain/domainValidateDomain.ts` [[7]](diffhunk://#diff-a332c72399688fcca81841ffccb3ce1ac406e5ecfac88bd48ca11a65b0c0c533R1-R34) `src/mcp/tools/domain/domainGenerateDomain.ts` [[8]](diffhunk://#diff-074f544b2d280135485d5b94fb6efd6062bca5fe5dc281e6efef19462c9164dcR1-R34) `src/mcp/tools/domain/domainCanGenerateTraefikMeDomains.ts` [[9]](diffhunk://#diff-3a2d06b73850e5e40bc23c989d9938335f484be74858898839bd8fe12843366aR1-R39)

* Added a domain tools index and integrated the new tools into the global tool registry, making them available throughout the MCP server. (`src/mcp/tools/domain/index.ts` [[1]](diffhunk://#diff-9be9135e35486f45648155c40275d8951beb2284b73e9c3376beab0e2ed0f604R1-R9) `src/mcp/tools/index.ts` [[2]](diffhunk://#diff-ca2db716a0fc2923ac94b5ccf40855c1b1f18ad153cac2a1289bba01fb27c757R2-R10)

**Documentation Updates:**

* Updated `README.md` and `TOOLS.md` to reflect the addition of the Domain Management category, increasing the total tool count from 58 to 67 and providing detailed documentation for each new domain tool. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L339-R339) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R366-R377) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L393-R405); `TOOLS.md` [[4]](diffhunk://#diff-806f3d0616e18ff8209e430b5c718c62e4a2f6ad6f2d4b2b2f21ad7c7e9d7f52L7-R10) [[5]](diffhunk://#diff-806f3d0616e18ff8209e430b5c718c62e4a2f6ad6f2d4b2b2f21ad7c7e9d7f52R485-R624)

These changes significantly enhance the platform's ability to manage domain-related operations, providing users with a robust and flexible set of tools for domain lifecycle management.…lect new features