### PR TITLE
feat: add compose stack tools

### DIFF
--- a/src/mcp/tools/compose/composeCleanQueues.ts
+++ b/src/mcp/tools/compose/composeCleanQueues.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import apiClient from "../../../utils/apiClient.js";
+import { ResponseFormatter } from "../../../utils/responseFormatter.js";
+import { createTool } from "../toolFactory.js";
+
+export const composeCleanQueues = createTool({
+  name: "compose-cleanQueues",
+  description:
+    "Cleans the deployment queues for a compose stack in Dokploy. Use this to unstick a stuck deployment.",
+  schema: z.object({
+    composeId: z
+      .string()
+      .describe("The ID of the compose stack to clean queues for."),
+  }),
+  annotations: {
+    title: "Clean Compose Queues",
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  handler: async (input) => {
+    const response = await apiClient.post("/compose.cleanQueues", input);
+
+    return ResponseFormatter.success(
+      `Compose stack "${input.composeId}" queues cleaned successfully`,
+      response.data
+    );
+  },
+});

--- a/src/mcp/tools/compose/composeCleanQueues.ts
+++ b/src/mcp/tools/compose/composeCleanQueues.ts
@@ -10,6 +10,7 @@ export const composeCleanQueues = createTool({
   schema: z.object({
     composeId: z
       .string()
+      .min(1)
       .describe("The ID of the compose stack to clean queues for."),
   }),
   annotations: {

--- a/src/mcp/tools/compose/composeDeploy.ts
+++ b/src/mcp/tools/compose/composeDeploy.ts
@@ -9,6 +9,7 @@ export const composeDeploy = createTool({
   schema: z.object({
     composeId: z
       .string()
+      .min(1)
       .describe("The ID of the compose stack to deploy."),
   }),
   annotations: {

--- a/src/mcp/tools/compose/composeDeploy.ts
+++ b/src/mcp/tools/compose/composeDeploy.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import apiClient from "../../../utils/apiClient.js";
+import { ResponseFormatter } from "../../../utils/responseFormatter.js";
+import { createTool } from "../toolFactory.js";
+
+export const composeDeploy = createTool({
+  name: "compose-deploy",
+  description: "Deploys a compose stack in Dokploy.",
+  schema: z.object({
+    composeId: z
+      .string()
+      .describe("The ID of the compose stack to deploy."),
+  }),
+  annotations: {
+    title: "Deploy Compose Stack",
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  handler: async (input) => {
+    const response = await apiClient.post("/compose.deploy", input);
+
+    return ResponseFormatter.success(
+      `Compose stack "${input.composeId}" deployment started successfully`,
+      response.data
+    );
+  },
+});

--- a/src/mcp/tools/compose/composeOne.ts
+++ b/src/mcp/tools/compose/composeOne.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import apiClient from "../../../utils/apiClient.js";
+import { ResponseFormatter } from "../../../utils/responseFormatter.js";
+import { createTool } from "../toolFactory.js";
+
+export const composeOne = createTool({
+  name: "compose-one",
+  description: "Retrieves details of a specific compose stack in Dokploy.",
+  schema: z.object({
+    composeId: z
+      .string()
+      .describe("The ID of the compose stack to retrieve."),
+  }),
+  annotations: {
+    title: "Get Compose Stack",
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  handler: async (input) => {
+    const response = await apiClient.get("/compose.one", {
+      params: input,
+    });
+
+    return ResponseFormatter.success(
+      `Compose stack "${input.composeId}" retrieved successfully`,
+      response.data
+    );
+  },
+});

--- a/src/mcp/tools/compose/composeOne.ts
+++ b/src/mcp/tools/compose/composeOne.ts
@@ -9,10 +9,12 @@ export const composeOne = createTool({
   schema: z.object({
     composeId: z
       .string()
+      .min(1)
       .describe("The ID of the compose stack to retrieve."),
   }),
   annotations: {
     title: "Get Compose Stack",
+    readOnlyHint: true,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: true,

--- a/src/mcp/tools/compose/composeRedeploy.ts
+++ b/src/mcp/tools/compose/composeRedeploy.ts
@@ -9,6 +9,7 @@ export const composeRedeploy = createTool({
   schema: z.object({
     composeId: z
       .string()
+      .min(1)
       .describe("The ID of the compose stack to redeploy."),
   }),
   annotations: {

--- a/src/mcp/tools/compose/composeRedeploy.ts
+++ b/src/mcp/tools/compose/composeRedeploy.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import apiClient from "../../../utils/apiClient.js";
+import { ResponseFormatter } from "../../../utils/responseFormatter.js";
+import { createTool } from "../toolFactory.js";
+
+export const composeRedeploy = createTool({
+  name: "compose-redeploy",
+  description: "Redeploys a compose stack in Dokploy (pulls latest images and restarts).",
+  schema: z.object({
+    composeId: z
+      .string()
+      .describe("The ID of the compose stack to redeploy."),
+  }),
+  annotations: {
+    title: "Redeploy Compose Stack",
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  handler: async (input) => {
+    const response = await apiClient.post("/compose.redeploy", input);
+
+    return ResponseFormatter.success(
+      `Compose stack "${input.composeId}" redeployment started successfully`,
+      response.data
+    );
+  },
+});

--- a/src/mcp/tools/compose/composeStart.ts
+++ b/src/mcp/tools/compose/composeStart.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import apiClient from "../../../utils/apiClient.js";
+import { ResponseFormatter } from "../../../utils/responseFormatter.js";
+import { createTool } from "../toolFactory.js";
+
+export const composeStart = createTool({
+  name: "compose-start",
+  description: "Starts a compose stack in Dokploy.",
+  schema: z.object({
+    composeId: z
+      .string()
+      .describe("The ID of the compose stack to start."),
+  }),
+  annotations: {
+    title: "Start Compose Stack",
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  handler: async (input) => {
+    const response = await apiClient.post("/compose.start", input);
+
+    return ResponseFormatter.success(
+      `Compose stack "${input.composeId}" started successfully`,
+      response.data
+    );
+  },
+});

--- a/src/mcp/tools/compose/composeStart.ts
+++ b/src/mcp/tools/compose/composeStart.ts
@@ -9,6 +9,7 @@ export const composeStart = createTool({
   schema: z.object({
     composeId: z
       .string()
+      .min(1)
       .describe("The ID of the compose stack to start."),
   }),
   annotations: {

--- a/src/mcp/tools/compose/composeStop.ts
+++ b/src/mcp/tools/compose/composeStop.ts
@@ -9,6 +9,7 @@ export const composeStop = createTool({
   schema: z.object({
     composeId: z
       .string()
+      .min(1)
       .describe("The ID of the compose stack to stop."),
   }),
   annotations: {

--- a/src/mcp/tools/compose/composeStop.ts
+++ b/src/mcp/tools/compose/composeStop.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import apiClient from "../../../utils/apiClient.js";
+import { ResponseFormatter } from "../../../utils/responseFormatter.js";
+import { createTool } from "../toolFactory.js";
+
+export const composeStop = createTool({
+  name: "compose-stop",
+  description: "Stops a running compose stack in Dokploy.",
+  schema: z.object({
+    composeId: z
+      .string()
+      .describe("The ID of the compose stack to stop."),
+  }),
+  annotations: {
+    title: "Stop Compose Stack",
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  handler: async (input) => {
+    const response = await apiClient.post("/compose.stop", input);
+
+    return ResponseFormatter.success(
+      `Compose stack "${input.composeId}" stopped successfully`,
+      response.data
+    );
+  },
+});

--- a/src/mcp/tools/compose/index.ts
+++ b/src/mcp/tools/compose/index.ts
@@ -1,0 +1,6 @@
+export { composeOne } from "./composeOne.js";
+export { composeDeploy } from "./composeDeploy.js";
+export { composeRedeploy } from "./composeRedeploy.js";
+export { composeStart } from "./composeStart.js";
+export { composeStop } from "./composeStop.js";
+export { composeCleanQueues } from "./composeCleanQueues.js";

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -1,4 +1,5 @@
 import * as applicationTools from "./application/index.js";
+import * as composeTools from "./compose/index.js";
 import * as domainTools from "./domain/index.js";
 import * as mysqlTools from "./mysql/index.js";
 import * as postgresTools from "./postgres/index.js";
@@ -7,6 +8,7 @@ import * as projectTools from "./project/index.js";
 export const allTools = [
   ...Object.values(projectTools),
   ...Object.values(applicationTools),
+  ...Object.values(composeTools),
   ...Object.values(domainTools),
   ...Object.values(mysqlTools),
   ...Object.values(postgresTools),


### PR DESCRIPTION
Closes #18.

I needed to manage compose stacks via MCP for my own project and ended up implementing these tools locally. When I saw issue #18 I figured it was worth contributing back.

Compose stacks had zero MCP support — no way to inspect, deploy, or manage them without going to the UI. This adds the missing tools:

| Tool | Endpoint |
|------|----------|
| `compose-one` | `GET /compose.one` |
| `compose-deploy` | `POST /compose.deploy` |
| `compose-redeploy` | `POST /compose.redeploy` |
| `compose-start` | `POST /compose.start` |
| `compose-stop` | `POST /compose.stop` |
| `compose-cleanQueues` | `POST /compose.cleanQueues` |

Tested against a live Dokploy instance — `compose-cleanQueues` was especially handy for clearing a stuck deployment queue.

@andradehenrique let me know if anything needs adjusting!