### PR TITLE
fix: emit JSON Schema draft 2020-12 for tools/list (#32)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "@modelcontextprotocol/sdk": "^1.12.0",
     "axios": "^1.9.0",
     "hono": "^4.12.12",
-    "zod": "^3.25.28"
+    "zod": "^3.25.28",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       zod:
         specifier: ^3.25.28
         version: 3.25.76
+      zod-to-json-schema:
+        specifier: ^3.25.2
+        version: 3.25.2(zod@3.25.76)
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.10
@@ -695,10 +698,10 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  zod-to-json-schema@3.25.1:
-    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
-      zod: ^3.25 || ^4
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -840,7 +843,7 @@ snapshots:
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
       zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -1303,7 +1306,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  zod-to-json-schema@3.25.1(zod@3.25.76):
+  zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { ZodObject, ZodRawShape } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 import { generatedTools } from "./generated/tools.js";
 import { createHandler } from "./handler.js";
 import { createLogger } from "./utils/logger.js";
 
 const logger = createLogger("MCP-Server");
+
+const JSON_SCHEMA_2020_12 = "https://json-schema.org/draft/2020-12/schema";
 
 function getEnabledTools() {
   const enabledTags = process.env.DOKPLOY_ENABLED_TAGS;
@@ -30,6 +35,38 @@ function getEnabledTools() {
   return filtered;
 }
 
+function stripNestedSchemaKeys(value: unknown): void {
+  if (value === null || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const item of value) stripNestedSchemaKeys(item);
+    return;
+  }
+  const record = value as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (key === "$schema") {
+      delete record[key];
+    } else {
+      stripNestedSchemaKeys(record[key]);
+    }
+  }
+}
+
+// Claude's API requires JSON Schema draft 2020-12. The MCP SDK's built-in
+// Zod→JSON Schema converter emits draft-07 by default, which causes a 400
+// error on tools/list. We bypass the SDK's auto-generated handler by
+// registering our own with pre-converted draft-2020-12 schemas.
+// See https://github.com/Dokploy/mcp/issues/32
+function toDraft2020_12JsonSchema(schema: ZodObject<ZodRawShape>): Record<string, unknown> {
+  const result = zodToJsonSchema(schema, {
+    target: "jsonSchema2019-09",
+    strictUnions: true,
+  }) as Record<string, unknown>;
+
+  stripNestedSchemaKeys(result);
+  result.$schema = JSON_SCHEMA_2020_12;
+  return result;
+}
+
 export function createServer() {
   const server = new McpServer({
     name: "dokploy",
@@ -47,6 +84,17 @@ export function createServer() {
       createHandler(tool),
     );
   }
+
+  const toolList = tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: toDraft2020_12JsonSchema(tool.schema),
+    annotations: tool.annotations,
+  }));
+
+  server.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: toolList,
+  }));
 
   return server;
 }


### PR DESCRIPTION
## Problem

Fixes #32.

When an MCP client (e.g. Anthropic's Claude API) calls `tools/list`, the server currently returns tool schemas tagged as `"$schema": "http://json-schema.org/draft-07/schema#"`. Claude's API strictly requires JSON Schema draft 2020-12 and rejects the whole response with a 400 `InvalidRequestError`, making every tool in this server unusable.

Root cause: `McpServer.tool()` auto-registers a `tools/list` handler that converts each Zod schema through the SDK's built-in `toJsonSchemaCompat()`. That helper delegates to `zod-to-json-schema` which emits draft-07 by default. Zod v3's `z.toJSONSchema` (draft 2020-12) lives only in `@modelcontextprotocol/core@2.0.0-alpha.1`, so every consumer of the stable SDK inherits the draft-07 output.

## Fix (Option A — pragmatic, ships today)

This PR overrides the auto-registered handler with a custom one that does the Zod → JSON Schema conversion in this package, then stamps the correct `$schema` draft. It does not touch SDK internals and does not require any alpha dependency.

Concretely, `src/server.ts`:

1. Registers all tools via `server.tool(...)` as before (so call handlers keep working).
2. Adds its own `ListToolsRequestSchema` handler that replaces the SDK default:
   - Convert each Zod schema with `zodToJsonSchema(..., { target: "jsonSchema2019-09", strictUnions: true })`.
   - Recursively strip any nested `$schema` keys.
   - Set the top-level `$schema` to `https://json-schema.org/draft/2020-12/schema`.

Draft 2019-09 is intentional: the `zod-to-json-schema` package doesn't expose a `"draft-2020-12"` target, but 2019-09 is a strict subset of 2020-12 for the features emitted here (`type`, `properties`, `required`, `enum`, `anyOf`, `description`, etc.), so relabeling is safe.

## Verification

Built the fixed server and connected a fresh Claude Code MCP client to it. All 87 tools now load:

```
✓ tools/list returns 87 tools
✓ every inputSchema has "$schema": "https://json-schema.org/draft/2020-12/schema"
✓ no draft-07 entries
✓ test calls on application-*, deployment-*, domain-*, postgres-*, project-*, server-* resolve cleanly
```

Checks:

```
pnpm install       # clean
pnpm type-check    # ok
pnpm lint          # ok
pnpm run build     # ok
```

## Dependencies

Adds `zod-to-json-schema` as a direct dependency (it was already transitive via the SDK) so the explicit import is covered.

## Notes / Option B

An alternative would be to route through Standard Schema, which is the path newer MCP SDKs are taking. That support lives in `@modelcontextprotocol/core@2.0.0-alpha.1`, which is an alpha release with breaking API changes. Once that lands in a stable SDK, this local conversion can be removed. Until then, Option A keeps the project on the current stable SDK and unblocks Claude clients immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)