### PR TITLE
fix: strip provider-incompatible email patterns

### DIFF
--- a/scripts/generate-tools.ts
+++ b/scripts/generate-tools.ts
@@ -65,7 +65,7 @@ function formatTitle(operationId: string): string {
 
 function getZodSchema(op: OperationObject, method: string): string {
   if (method === "post" && op.requestBody?.content?.["application/json"]?.schema) {
-    const schema = op.requestBody.content["application/json"].schema;
+    const schema = normalizeToolSchema(op.requestBody.content["application/json"].schema);
     return jsonSchemaToZod(schema);
   }
 
@@ -76,7 +76,10 @@ function getZodSchema(op: OperationObject, method: string): string {
     for (const param of op.parameters) {
       const paramSchema =
         typeof param.schema === "object" && param.schema !== null
-          ? { ...param.schema, ...(param.description ? { description: param.description } : {}) }
+          ? normalizeToolSchema({
+              ...param.schema,
+              ...(param.description ? { description: param.description } : {}),
+            })
           : param.schema;
       properties[param.name] = paramSchema;
       if (param.required) {
@@ -92,6 +95,33 @@ function getZodSchema(op: OperationObject, method: string): string {
   }
 
   return "z.object({})";
+}
+
+const DOKPLOY_EMAIL_LOOKAROUND_PATTERN =
+  "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$";
+
+function normalizeToolSchema(schema: JsonSchema): JsonSchema {
+  const normalized = structuredClone(schema) as JsonSchema;
+  stripProviderIncompatibleEmailPatterns(normalized);
+  return normalized;
+}
+
+function stripProviderIncompatibleEmailPatterns(schema: unknown): void {
+  if (schema === null || typeof schema !== "object") return;
+
+  if (Array.isArray(schema)) {
+    for (const item of schema) stripProviderIncompatibleEmailPatterns(item);
+    return;
+  }
+
+  const record = schema as Record<string, unknown>;
+  if (record.format === "email" && record.pattern === DOKPLOY_EMAIL_LOOKAROUND_PATTERN) {
+    delete record.pattern;
+  }
+
+  for (const value of Object.values(record)) {
+    stripProviderIncompatibleEmailPatterns(value);
+  }
 }
 
 interface JsonSchemaObject {

--- a/src/generated/tools.ts
+++ b/src/generated/tools.ts
@@ -1,5 +1,5 @@
 // AUTO-GENERATED FILE — DO NOT EDIT MANUALLY
-// Generated from openapi.json on 2026-04-25
+// Generated from openapi.json on 2026-06-01
 // Run `pnpm generate` to regenerate
 
 import { z } from "zod";
@@ -540,7 +540,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "bitbucket",
     method: "POST",
     path: "/bitbucket.create",
-    schema: z.object({ "bitbucketId": z.string().optional(), "bitbucketUsername": z.string().optional(), "bitbucketEmail": z.string().email().regex(new RegExp("^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$")).optional(), "appPassword": z.string().optional(), "apiToken": z.string().optional(), "bitbucketWorkspaceName": z.string().optional(), "gitProviderId": z.string().optional(), "authId": z.string().min(1), "name": z.string().min(1) }),
+    schema: z.object({ "bitbucketId": z.string().optional(), "bitbucketUsername": z.string().optional(), "bitbucketEmail": z.string().email().optional(), "appPassword": z.string().optional(), "apiToken": z.string().optional(), "bitbucketWorkspaceName": z.string().optional(), "gitProviderId": z.string().optional(), "authId": z.string().min(1), "name": z.string().min(1) }),
     annotations: {
       title: "Bitbucket Create",
       ...{"openWorldHint":true},
@@ -600,7 +600,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "bitbucket",
     method: "POST",
     path: "/bitbucket.testConnection",
-    schema: z.object({ "bitbucketId": z.string().min(1), "bitbucketUsername": z.string().optional(), "bitbucketEmail": z.string().email().regex(new RegExp("^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$")).optional(), "workspaceName": z.string().optional(), "apiToken": z.string().optional(), "appPassword": z.string().optional() }),
+    schema: z.object({ "bitbucketId": z.string().min(1), "bitbucketUsername": z.string().optional(), "bitbucketEmail": z.string().email().optional(), "workspaceName": z.string().optional(), "apiToken": z.string().optional(), "appPassword": z.string().optional() }),
     annotations: {
       title: "Bitbucket TestConnection",
       ...{"idempotentHint":true,"openWorldHint":true},
@@ -612,7 +612,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "bitbucket",
     method: "POST",
     path: "/bitbucket.update",
-    schema: z.object({ "bitbucketId": z.string().min(1), "bitbucketUsername": z.string().optional(), "bitbucketEmail": z.string().email().regex(new RegExp("^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$")).optional(), "appPassword": z.string().optional(), "apiToken": z.string().optional(), "bitbucketWorkspaceName": z.string().optional(), "gitProviderId": z.string(), "name": z.string().min(1), "organizationId": z.string().optional() }),
+    schema: z.object({ "bitbucketId": z.string().min(1), "bitbucketUsername": z.string().optional(), "bitbucketEmail": z.string().email().optional(), "appPassword": z.string().optional(), "apiToken": z.string().optional(), "bitbucketWorkspaceName": z.string().optional(), "gitProviderId": z.string(), "name": z.string().min(1), "organizationId": z.string().optional() }),
     annotations: {
       title: "Bitbucket Update",
       ...{"idempotentHint":true,"openWorldHint":true},
@@ -4284,7 +4284,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "settings",
     method: "POST",
     path: "/settings.assignDomainServer",
-    schema: z.object({ "host": z.string(), "certificateType": z.enum(["letsencrypt","none","custom"]), "letsEncryptEmail": z.union([z.union([z.string().email().regex(new RegExp("^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$")), z.literal("")]), z.null()]).optional(), "https": z.boolean().optional() }),
+    schema: z.object({ "host": z.string(), "certificateType": z.enum(["letsencrypt","none","custom"]), "letsEncryptEmail": z.union([z.union([z.string().email(), z.literal("")]), z.null()]).optional(), "https": z.boolean().optional() }),
     annotations: {
       title: "Settings AssignDomainServer",
       ...{"idempotentHint":true,"openWorldHint":true},
@@ -5028,7 +5028,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "user",
     method: "POST",
     path: "/user.update",
-    schema: z.object({ "id": z.string().min(1).optional(), "firstName": z.string().optional(), "lastName": z.string().optional(), "isRegistered": z.boolean().optional(), "expirationDate": z.string().optional(), "createdAt2": z.string().optional(), "createdAt": z.union([z.string(), z.null()]).optional(), "twoFactorEnabled": z.union([z.boolean(), z.null()]).optional(), "email": z.string().email().regex(new RegExp("^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$")).min(1).optional(), "emailVerified": z.boolean().optional(), "image": z.union([z.string(), z.null()]).optional(), "banned": z.union([z.boolean(), z.null()]).optional(), "banReason": z.union([z.string(), z.null()]).optional(), "banExpires": z.union([z.string(), z.null()]).optional(), "updatedAt": z.string().optional(), "enablePaidFeatures": z.boolean().optional(), "allowImpersonation": z.boolean().optional(), "enableEnterpriseFeatures": z.boolean().optional(), "licenseKey": z.union([z.string(), z.null()]).optional(), "stripeCustomerId": z.union([z.string(), z.null()]).optional(), "stripeSubscriptionId": z.union([z.string(), z.null()]).optional(), "serversQuantity": z.number().optional(), "sendInvoiceNotifications": z.boolean().optional(), "password": z.string().optional(), "currentPassword": z.string().optional() }),
+    schema: z.object({ "id": z.string().min(1).optional(), "firstName": z.string().optional(), "lastName": z.string().optional(), "isRegistered": z.boolean().optional(), "expirationDate": z.string().optional(), "createdAt2": z.string().optional(), "createdAt": z.union([z.string(), z.null()]).optional(), "twoFactorEnabled": z.union([z.boolean(), z.null()]).optional(), "email": z.string().email().min(1).optional(), "emailVerified": z.boolean().optional(), "image": z.union([z.string(), z.null()]).optional(), "banned": z.union([z.boolean(), z.null()]).optional(), "banReason": z.union([z.string(), z.null()]).optional(), "banExpires": z.union([z.string(), z.null()]).optional(), "updatedAt": z.string().optional(), "enablePaidFeatures": z.boolean().optional(), "allowImpersonation": z.boolean().optional(), "enableEnterpriseFeatures": z.boolean().optional(), "licenseKey": z.union([z.string(), z.null()]).optional(), "stripeCustomerId": z.union([z.string(), z.null()]).optional(), "stripeSubscriptionId": z.union([z.string(), z.null()]).optional(), "serversQuantity": z.number().optional(), "sendInvoiceNotifications": z.boolean().optional(), "password": z.string().optional(), "currentPassword": z.string().optional() }),
     annotations: {
       title: "User Update",
       ...{"idempotentHint":true,"openWorldHint":true},
@@ -5160,7 +5160,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "user",
     method: "POST",
     path: "/user.createUserWithCredentials",
-    schema: z.object({ "email": z.string().email().regex(new RegExp("^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$")), "password": z.string().min(8), "role": z.string().min(1) }),
+    schema: z.object({ "email": z.string().email(), "password": z.string().min(8), "role": z.string().min(1) }),
     annotations: {
       title: "User CreateUserWithCredentials",
       ...{"openWorldHint":true},
@@ -5412,7 +5412,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "organization",
     method: "POST",
     path: "/organization.inviteMember",
-    schema: z.object({ "email": z.string().email().regex(new RegExp("^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$")), "role": z.string().min(1) }),
+    schema: z.object({ "email": z.string().email(), "role": z.string().min(1) }),
     annotations: {
       title: "Organization InviteMember",
       ...{"idempotentHint":true,"openWorldHint":true},

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -33,10 +33,9 @@ describe("MCP server tools/list", () => {
     const tools = await getToolList();
     for (const tool of tools) {
       const schema = tool.inputSchema as Record<string, unknown>;
-      expect(
-        schema.$schema,
-        `Tool "${tool.name}" is missing $schema or has wrong draft`,
-      ).toBe("https://json-schema.org/draft/2020-12/schema");
+      expect(schema.$schema, `Tool "${tool.name}" is missing $schema or has wrong draft`).toBe(
+        "https://json-schema.org/draft/2020-12/schema",
+      );
     }
   });
 
@@ -60,7 +59,10 @@ describe("MCP server tools/list", () => {
 
     for (const tool of tools) {
       const found = findNestedSchemaKeys(tool.inputSchema);
-      expect(found, `Tool "${tool.name}" has nested $schema keys at: ${found.join(", ")}`).toHaveLength(0);
+      expect(
+        found,
+        `Tool "${tool.name}" has nested $schema keys at: ${found.join(", ")}`,
+      ).toHaveLength(0);
     }
   });
 
@@ -73,6 +75,36 @@ describe("MCP server tools/list", () => {
         (tool.inputSchema as Record<string, unknown>).type,
         `tool "${tool.name}" inputSchema is missing type`,
       ).toBe("object");
+    }
+  });
+
+  it("does not emit provider-incompatible regex lookarounds", async () => {
+    const tools = await getToolList();
+
+    function findLookaroundPatterns(obj: unknown, path = ""): string[] {
+      if (obj === null || typeof obj !== "object") return [];
+      if (Array.isArray(obj)) {
+        return obj.flatMap((item, i) => findLookaroundPatterns(item, `${path}[${i}]`));
+      }
+
+      const record = obj as Record<string, unknown>;
+      const found: string[] = [];
+      for (const [key, value] of Object.entries(record)) {
+        const currentPath = path ? `${path}.${key}` : key;
+        if (key === "pattern" && typeof value === "string" && value.includes("(?!")) {
+          found.push(`${currentPath}: ${value}`);
+        }
+        found.push(...findLookaroundPatterns(value, currentPath));
+      }
+      return found;
+    }
+
+    for (const tool of tools) {
+      const found = findLookaroundPatterns(tool.inputSchema);
+      expect(
+        found,
+        `Tool "${tool.name}" has provider-incompatible regex lookarounds at: ${found.join(", ")}`,
+      ).toHaveLength(0);
     }
   });
 });


### PR DESCRIPTION
Fixes #45.

## Summary

- strip the generated email lookaround regex from MCP tool schemas
- keep `z.string().email()` validation for affected email fields
- add a tools/list regression test for provider-incompatible regex lookarounds

## Why

OpenAI's tool schema validator and Anthropic Sonnet strict mode reject regex lookarounds in tool input schemas. The generated Dokploy tools currently emit the same lookaround email pattern for Bitbucket, domain, user, and organization email fields, which prevents strict clients from accepting the tool list.

This keeps the server-side API validation unchanged and only removes the provider-incompatible generated schema pattern.

## Verification

- `npx --yes pnpm@10.24.0 generate`
- `npx --yes pnpm@10.24.0 test -- src/server.test.ts`
- `npx --yes pnpm@10.24.0 type-check`
- `npx --yes pnpm@10.24.0 lint`
- `npx --yes pnpm@10.24.0 build`
- `git diff --check`