### PR TITLE
feat: update doc to add opencode installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,26 @@ Open the "Settings" page of the app, navigate to "Plugins," and enter the follow
 }
 ```
 
+### Install in Opencode
+
+Add this to your OpenCode configuration (located by default in ~/.config/opencode/opencode.json or opencode.json for local/project config). See [Opencode MCP config](https://opencode.ai/docs/mcp-servers/) for more info.
+
+```json
+{
+  "mcp": {
+    "dokploy": {
+      "type": "local",
+      "command": ["npx", "-y", "@dokploy/mcp"],
+      "environment": {
+        "DOKPLOY_URL": "https://your-dokploy-server.com",
+        "DOKPLOY_API_KEY": "your-dokploy-api-token"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
 ### Using Docker
 
 The Docker container supports both **stdio** and **HTTP** transport modes, making it flexible for different deployment scenarios.


### PR DESCRIPTION
## Summary

- Add instruction to install the MCP on Opencode

## Why

The configuration for Opencode is a little different from the others. Adding a note in the README makes the task easier.

## Verification
- Running the `list` command for MCP
```bash
> opencode mcp list                                                                                                                                                                                                                                                                                                 

┌  MCP Servers
│
●  ✓ dokploy connected
│      npx -y @dokploy/mcp
│
└  1 server(s)

```