### PR TITLE
feat: add toolset presets for large MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Use `DOKPLOY_TOOL_PRESET` for common workflows:
 | `all` | All tools (default) |
 | `minimal` | `project`, `application` |
 | `core` | `project`, `server`, `application` |
-| `deploy` | `project`, `environment`, `server`, `application`, `domain`, `deployment` |
+| `deploy` | `project`, `environment`, `server`, `application`, `compose`, `domain`, `deployment` |
 | `databases` | `postgres`, `redis`, `mysql`, `mariadb`, `mongo`, `libsql` |
 | `git` | `github`, `gitlab`, `bitbucket`, `gitea`, `gitProvider`, `registry`, `sshKey` |
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,9 @@ The configuration on Windows is slightly different compared to Linux or macOS. U
 | `DOKPLOY_URL` | Yes | Your Dokploy server URL (e.g., `https://your-dokploy-server.com`) |
 | `DOKPLOY_API_KEY` | Yes | Your Dokploy API authentication token |
 | `DOKPLOY_CUSTOM_HEADERS` | No | JSON object of additional upstream request headers. Header names and values must be strings. Reserved headers cannot be set here: `x-api-key`, `content-type`, `accept`. |
+| `DOKPLOY_TOOL_PRESET` | No | Predefined toolset to load: `all` (default), `minimal`, `core`, `deploy`, `databases`, or `git`. Useful for clients/providers that struggle with very large tool lists. |
 | `DOKPLOY_ENABLED_TAGS` | No | Comma-separated list of tags to filter which tools are loaded (e.g., `project,application,postgres`) |
+| `DOKPLOY_DISABLED_TAGS` | No | Comma-separated list of tags to exclude from the selected toolset. Applied after `DOKPLOY_TOOL_PRESET` or `DOKPLOY_ENABLED_TAGS`. |
 | `DOKPLOY_TIMEOUT` | No | Request timeout in milliseconds (default: `30000`) |
 | `DOKPLOY_RETRY_ATTEMPTS` | No | Number of retry attempts (default: `3`) |
 | `DOKPLOY_RETRY_DELAY` | No | Delay between retries in milliseconds (default: `1000`) |
@@ -443,12 +445,39 @@ This MCP server provides **508 tools** covering the entire Dokploy API, organize
 
 ### Tool Filtering
 
-You can limit which tools are loaded by setting the `DOKPLOY_ENABLED_TAGS` environment variable. This is useful when you only need a subset of tools:
+By default, the server exposes all Dokploy API tools. Some MCP clients and LLM providers can be slower or less reliable when very large tool lists are sent to the model. You can reduce the loaded tools with presets or tag filters.
+
+Use `DOKPLOY_TOOL_PRESET` for common workflows:
+
+| Preset | Included tags |
+|--------|---------------|
+| `all` | All tools (default) |
+| `minimal` | `project`, `application` |
+| `core` | `project`, `server`, `application` |
+| `deploy` | `project`, `environment`, `server`, `application`, `domain`, `deployment` |
+| `databases` | `postgres`, `redis`, `mysql`, `mariadb`, `mongo`, `libsql` |
+| `git` | `github`, `gitlab`, `bitbucket`, `gitea`, `gitProvider`, `registry`, `sshKey` |
+
+```bash
+# Recommended starting point for clients/providers sensitive to large toolsets
+DOKPLOY_TOOL_PRESET=minimal
+```
+
+For exact control, set `DOKPLOY_ENABLED_TAGS`:
 
 ```bash
 # Only load project, application, and postgres tools
 DOKPLOY_ENABLED_TAGS=project,application,postgres
 ```
+
+You can also remove categories from a preset:
+
+```bash
+DOKPLOY_TOOL_PRESET=core
+DOKPLOY_DISABLED_TAGS=postgres,redis
+```
+
+If `DOKPLOY_ENABLED_TAGS` is set, it takes precedence over `DOKPLOY_TOOL_PRESET`. `DOKPLOY_DISABLED_TAGS` is applied last.
 
 All tools include semantic annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`) to help MCP clients understand their behavior and safety characteristics.
 
@@ -519,7 +548,7 @@ npx -y @modelcontextprotocol/inspector npx @dokploy/mcp
 
 3. Verify your `DOKPLOY_URL` and `DOKPLOY_API_KEY` environment variables are correctly set.
 
-4. If too many tools are loading, use `DOKPLOY_ENABLED_TAGS` to filter by category.
+4. If too many tools are loading or your provider times out while processing tools, start with `DOKPLOY_TOOL_PRESET=minimal`, then use `DOKPLOY_ENABLED_TAGS` for exact category filtering if needed.
 
 ## Contributing
 

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -11,6 +11,12 @@ vi.mock("./utils/apiClient.js", () => ({
 }));
 
 const { createServer } = await import("./server.js");
+const { generatedTools } = await import("./generated/tools.js");
+
+function countByTags(tags: string[]): number {
+  const wanted = new Set(tags.map((tag) => tag.toLowerCase()));
+  return generatedTools.filter((tool) => wanted.has(tool.tag.toLowerCase())).length;
+}
 
 describe("MCP server tools/list", () => {
   const toolsetEnvVars = ["DOKPLOY_ENABLED_TAGS", "DOKPLOY_DISABLED_TAGS", "DOKPLOY_TOOL_PRESET"];
@@ -39,7 +45,7 @@ describe("MCP server tools/list", () => {
 
   it("returns all tools by default", async () => {
     const tools = await getToolList();
-    expect(tools).toHaveLength(524);
+    expect(tools).toHaveLength(generatedTools.length);
   });
 
   it("supports DOKPLOY_TOOL_PRESET=minimal for clients sensitive to large toolsets", async () => {
@@ -48,7 +54,7 @@ describe("MCP server tools/list", () => {
     const tools = await getToolList();
     const tags = new Set(tools.map((tool) => tool.name.split("-")[0]));
 
-    expect(tools).toHaveLength(40);
+    expect(tools).toHaveLength(countByTags(["project", "application"]));
     expect(tags).toEqual(new Set(["application", "project"]));
   });
 
@@ -58,7 +64,7 @@ describe("MCP server tools/list", () => {
     const tools = await getToolList();
     const tags = new Set(tools.map((tool) => tool.name.split("-")[0]));
 
-    expect(tools).toHaveLength(57);
+    expect(tools).toHaveLength(countByTags(["project", "server", "application"]));
     expect(tags).toEqual(new Set(["application", "project", "server"]));
   });
 
@@ -69,7 +75,7 @@ describe("MCP server tools/list", () => {
     const tools = await getToolList();
     const tags = new Set(tools.map((tool) => tool.name.split("-")[0]));
 
-    expect(tools).toHaveLength(40);
+    expect(tools).toHaveLength(countByTags(["project", "application"]));
     expect(tags).toEqual(new Set(["application", "project"]));
   });
 
@@ -80,7 +86,9 @@ describe("MCP server tools/list", () => {
     const tools = await getToolList();
     const tags = new Set(tools.map((tool) => tool.name.split("-")[0]));
 
-    expect(tools).toHaveLength(64);
+    expect(tools).toHaveLength(
+      countByTags(["project", "environment", "server", "application", "compose"]),
+    );
     expect(tags.has("domain")).toBe(false);
     expect(tags.has("deployment")).toBe(false);
   });
@@ -90,7 +98,7 @@ describe("MCP server tools/list", () => {
 
     const tools = await getToolList();
 
-    expect(tools).toHaveLength(524);
+    expect(tools).toHaveLength(generatedTools.length);
   });
 
   it("every tool inputSchema has $schema set to draft 2020-12", async () => {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,6 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Mock apiClient before server.ts is imported — it calls getClientConfig() at
 // module level which requires DOKPLOY_URL/DOKPLOY_API_KEY env vars.
@@ -13,6 +13,14 @@ vi.mock("./utils/apiClient.js", () => ({
 const { createServer } = await import("./server.js");
 
 describe("MCP server tools/list", () => {
+  const toolsetEnvVars = ["DOKPLOY_ENABLED_TAGS", "DOKPLOY_DISABLED_TAGS", "DOKPLOY_TOOL_PRESET"];
+
+  afterEach(() => {
+    for (const envVar of toolsetEnvVars) {
+      delete process.env[envVar];
+    }
+  });
+
   async function getToolList() {
     const server = createServer();
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -27,6 +35,62 @@ describe("MCP server tools/list", () => {
   it("returns tools", async () => {
     const tools = await getToolList();
     expect(tools.length).toBeGreaterThan(0);
+  });
+
+  it("returns all tools by default", async () => {
+    const tools = await getToolList();
+    expect(tools).toHaveLength(524);
+  });
+
+  it("supports DOKPLOY_TOOL_PRESET=minimal for clients sensitive to large toolsets", async () => {
+    process.env.DOKPLOY_TOOL_PRESET = "minimal";
+
+    const tools = await getToolList();
+    const tags = new Set(tools.map((tool) => tool.name.split("-")[0]));
+
+    expect(tools).toHaveLength(40);
+    expect(tags).toEqual(new Set(["application", "project"]));
+  });
+
+  it("supports DOKPLOY_TOOL_PRESET=core for common application workflows", async () => {
+    process.env.DOKPLOY_TOOL_PRESET = "core";
+
+    const tools = await getToolList();
+    const tags = new Set(tools.map((tool) => tool.name.split("-")[0]));
+
+    expect(tools).toHaveLength(57);
+    expect(tags).toEqual(new Set(["application", "project", "server"]));
+  });
+
+  it("lets DOKPLOY_ENABLED_TAGS override presets", async () => {
+    process.env.DOKPLOY_TOOL_PRESET = "core";
+    process.env.DOKPLOY_ENABLED_TAGS = "project,application";
+
+    const tools = await getToolList();
+    const tags = new Set(tools.map((tool) => tool.name.split("-")[0]));
+
+    expect(tools).toHaveLength(40);
+    expect(tags).toEqual(new Set(["application", "project"]));
+  });
+
+  it("excludes DOKPLOY_DISABLED_TAGS after selecting tools", async () => {
+    process.env.DOKPLOY_TOOL_PRESET = "deploy";
+    process.env.DOKPLOY_DISABLED_TAGS = "domain,deployment";
+
+    const tools = await getToolList();
+    const tags = new Set(tools.map((tool) => tool.name.split("-")[0]));
+
+    expect(tools).toHaveLength(64);
+    expect(tags.has("domain")).toBe(false);
+    expect(tags.has("deployment")).toBe(false);
+  });
+
+  it("falls back to all tools for an unknown preset", async () => {
+    process.env.DOKPLOY_TOOL_PRESET = "unknown";
+
+    const tools = await getToolList();
+
+    expect(tools).toHaveLength(524);
   });
 
   it("every tool inputSchema has $schema set to draft 2020-12", async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,28 +9,79 @@ import { createLogger } from "./utils/logger.js";
 const logger = createLogger("MCP-Server");
 
 const JSON_SCHEMA_2020_12 = "https://json-schema.org/draft/2020-12/schema";
+const LARGE_TOOLSET_WARNING_THRESHOLD = 150;
+
+const TOOL_PRESETS = {
+  all: null,
+  minimal: "project,application",
+  core: "project,server,application",
+  deploy: "project,environment,server,application,domain,deployment",
+  databases: "postgres,redis,mysql,mariadb,mongo,libsql",
+  git: "github,gitlab,bitbucket,gitea,gitProvider,registry,sshKey",
+} as const;
+
+type ToolPreset = keyof typeof TOOL_PRESETS;
+
+function parseTagList(value: string | undefined): Set<string> {
+  return new Set(
+    (value ?? "")
+      .split(",")
+      .map((tag) => tag.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+function isToolPreset(value: string): value is ToolPreset {
+  return Object.hasOwn(TOOL_PRESETS, value);
+}
 
 function getEnabledTools() {
   const enabledTags = process.env.DOKPLOY_ENABLED_TAGS;
+  const disabledTags = parseTagList(process.env.DOKPLOY_DISABLED_TAGS);
+  const requestedPreset = process.env.DOKPLOY_TOOL_PRESET?.trim().toLowerCase() || "all";
+  const preset: ToolPreset = isToolPreset(requestedPreset) ? requestedPreset : "all";
 
-  if (!enabledTags) {
-    return generatedTools;
+  if (!isToolPreset(requestedPreset)) {
+    logger.warn("Unknown tool preset, falling back to all tools", {
+      requestedPreset,
+      availablePresets: Object.keys(TOOL_PRESETS),
+    });
   }
 
-  const tags = new Set(
-    enabledTags
-      .split(",")
-      .map((t) => t.trim().toLowerCase())
-      .filter(Boolean),
-  );
+  let selectedTags = parseTagList(enabledTags);
+  const source = selectedTags.size > 0 ? "enabled-tags" : "preset";
 
-  const filtered = generatedTools.filter((tool) => tags.has(tool.tag.toLowerCase()));
+  if (selectedTags.size === 0) {
+    selectedTags = parseTagList(TOOL_PRESETS[preset] ?? undefined);
+  }
 
-  logger.info("Filtered tools by tags", {
-    enabledTags: [...tags],
+  let filtered =
+    selectedTags.size > 0
+      ? generatedTools.filter((tool) => selectedTags.has(tool.tag.toLowerCase()))
+      : generatedTools;
+
+  if (disabledTags.size > 0) {
+    filtered = filtered.filter((tool) => !disabledTags.has(tool.tag.toLowerCase()));
+  }
+
+  const context = {
     total: generatedTools.length,
     loaded: filtered.length,
-  });
+    source,
+    preset,
+    enabledTags: [...selectedTags],
+    disabledTags: [...disabledTags],
+  };
+
+  logger.info("Loaded tools", context);
+
+  if (filtered.length > LARGE_TOOLSET_WARNING_THRESHOLD) {
+    logger.warn("Large toolset loaded; some MCP clients or LLM providers may time out", {
+      ...context,
+      recommendation:
+        "Set DOKPLOY_TOOL_PRESET=minimal or DOKPLOY_ENABLED_TAGS to reduce tool count",
+    });
+  }
 
   return filtered;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,7 @@ const TOOL_PRESETS = {
   all: null,
   minimal: "project,application",
   core: "project,server,application",
-  deploy: "project,environment,server,application,domain,deployment",
+  deploy: "project,environment,server,application,compose,domain,deployment",
   databases: "postgres,redis,mysql,mariadb,mongo,libsql",
   git: "github,gitlab,bitbucket,gitea,gitProvider,registry,sshKey",
 } as const;


### PR DESCRIPTION
## Summary

Add toolset presets and exclusion filters so users can reduce the number of MCP tools exposed to clients/providers that struggle with very large tool lists.

By default, behavior stays unchanged: all Dokploy tools are loaded.

## Changes

- Add `DOKPLOY_TOOL_PRESET`
  - `all` (default)
  - `minimal`
  - `core`
  - `deploy`
  - `databases`
  - `git`
- Add `DOKPLOY_DISABLED_TAGS` to exclude categories after selecting a preset or explicit tag list.
- Keep `DOKPLOY_ENABLED_TAGS` as exact-control override.
- Add logging for selected toolset, loaded tool count, and large toolset warnings.
- Document presets, precedence, and troubleshooting guidance.
- Add tests for default behavior, presets, explicit tags, disabled tags, and invalid preset fallback.

## Presets

- `minimal`: `project`, `application`
- `core`: `project`, `server`, `application`
- `deploy`: `project`, `environment`, `server`, `application`, `domain`, `deployment`
- `databases`: `postgres`, `redis`, `mysql`, `mariadb`, `mongo`, `libsql`
- `git`: `github`, `gitlab`, `bitbucket`, `gitea`, `gitProvider`, `registry`, `sshKey`

## Why

The server exposes hundreds of tools when all Dokploy API categories are enabled. Some MCP clients and LLM providers can time out(e.g. GPT models) or fail when ingesting very large tool lists.

This allows us to maintain full API coverage by default while providing users with a documented way to reduce the number of tools.

## Configuration precedence

1. `DOKPLOY_ENABLED_TAGS` takes precedence when set.
2. Otherwise `DOKPLOY_TOOL_PRESET` selects a predefined toolset.
3. `DOKPLOY_DISABLED_TAGS` is applied last.
4. Default remains `DOKPLOY_TOOL_PRESET=all`.

## Testing

- `npx --yes pnpm@10.24.0 test -- src/server.test.ts`
- `npx --yes pnpm@10.24.0 type-check`
- `npx --yes pnpm@10.24.0 lint`
- `npx --yes pnpm@10.24.0 build`

Manual smoke checks:

- default loads 524 tools
- `DOKPLOY_TOOL_PRESET=minimal` loads 40 tools
- `DOKPLOY_TOOL_PRESET=core` loads 57 tools
- `DOKPLOY_ENABLED_TAGS=project,application,postgres` loads 56 tools