### PR TITLE
feat: expose deployment log reader

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -2,8 +2,8 @@
 
 > Auto-generated from the [Dokploy OpenAPI spec](https://docs.dokploy.com/openapi.json). Run `pnpm generate` to update.
 
-- **Total Tools**: 524
-- **Categories**: 48
+- **Total Tools**: 541
+- **Categories**: 49
 
 ## Categories
 
@@ -15,13 +15,14 @@
 - [bitbucket](#bitbucket) (7 tools)
 - [certificates](#certificates) (5 tools)
 - [cluster](#cluster) (4 tools)
-- [compose](#compose) (30 tools)
+- [compose](#compose) (31 tools)
 - [customRole](#customRole) (6 tools)
-- [deployment](#deployment) (8 tools)
+- [deployment](#deployment) (9 tools)
 - [destination](#destination) (6 tools)
 - [docker](#docker) (12 tools)
 - [domain](#domain) (9 tools)
 - [environment](#environment) (7 tools)
+- [forwardAuth](#forwardAuth) (10 tools)
 - [gitea](#gitea) (8 tools)
 - [github](#github) (6 tools)
 - [gitlab](#gitlab) (7 tools)
@@ -45,10 +46,10 @@
 - [rollback](#rollback) (2 tools)
 - [schedule](#schedule) (6 tools)
 - [security](#security) (4 tools)
-- [server](#server) (17 tools)
-- [settings](#settings) (51 tools)
+- [server](#server) (18 tools)
+- [settings](#settings) (54 tools)
 - [sshKey](#sshKey) (7 tools)
-- [sso](#sso) (10 tools)
+- [sso](#sso) (11 tools)
 - [stripe](#stripe) (8 tools)
 - [swarm](#swarm) (4 tools)
 - [tag](#tag) (8 tools)
@@ -92,12 +93,12 @@
 | `application-redeploy` | POST | `applicationId` (string), `title`?, `description`? |
 | `application-saveEnvironment` | POST | `applicationId` (string), `env` (string | null), `buildArgs` (string | null), `buildSecrets` (string | null), `createEnvFile` (boolean) |
 | `application-saveBuildType` | POST | `applicationId` (string), `buildType` ("dockerfile" | "heroku_buildpacks" | "paketo_buildpacks" | "nixpacks" | "static" | "railpack"), `dockerfile` (string | null), `dockerContextPath` (string | null), `dockerBuildStage` (string | null), `herokuVersion` (string | null), `railpackVersion` (string | null), `publishDirectory`?, `isStaticSpa`? |
-| `application-saveGithubProvider` | POST | `applicationId` (string), `repository` (string | null), `branch` (string | null), `owner` (string | null), `buildPath` (string | null), `githubId` (string | null), `triggerType` ("push" | "tag"), `enableSubmodules`?, `watchPaths`? |
-| `application-saveGitlabProvider` | POST | `applicationId` (string), `gitlabBranch` (string | null), `gitlabBuildPath` (string | null), `gitlabOwner` (string | null), `gitlabRepository` (string | null), `gitlabId` (string | null), `gitlabProjectId` (number | null), `gitlabPathNamespace` (string | null), `enableSubmodules`?, `watchPaths`? |
-| `application-saveBitbucketProvider` | POST | `bitbucketBranch` (string | null), `bitbucketBuildPath` (string | null), `bitbucketOwner` (string | null), `bitbucketRepository` (string | null), `bitbucketRepositorySlug` (string | null), `bitbucketId` (string | null), `applicationId` (string), `enableSubmodules`?, `watchPaths`? |
-| `application-saveGiteaProvider` | POST | `applicationId` (string), `giteaBranch` (string | null), `giteaBuildPath` (string | null), `giteaOwner` (string | null), `giteaRepository` (string | null), `giteaId` (string | null), `enableSubmodules`?, `watchPaths`? |
+| `application-saveGithubProvider` | POST | `applicationId` (string), `repository` (string | null), `owner` (string | null), `buildPath` (string | null), `githubId` (string | null), `branch` (string), `triggerType` ("push" | "tag"), `enableSubmodules`?, `watchPaths`? |
+| `application-saveGitlabProvider` | POST | `applicationId` (string), `gitlabBuildPath` (string | null), `gitlabOwner` (string | null), `gitlabRepository` (string | null), `gitlabId` (string | null), `gitlabProjectId` (number | null), `gitlabPathNamespace` (string | null), `gitlabBranch` (string), `enableSubmodules`?, `watchPaths`? |
+| `application-saveBitbucketProvider` | POST | `bitbucketBuildPath` (string | null), `bitbucketOwner` (string | null), `bitbucketRepository` (string | null), `bitbucketRepositorySlug` (string | null), `bitbucketId` (string | null), `applicationId` (string), `bitbucketBranch` (string), `enableSubmodules`?, `watchPaths`? |
+| `application-saveGiteaProvider` | POST | `applicationId` (string), `giteaBuildPath` (string | null), `giteaOwner` (string | null), `giteaRepository` (string | null), `giteaId` (string | null), `giteaBranch` (string), `enableSubmodules`?, `watchPaths`? |
 | `application-saveDockerProvider` | POST | `dockerImage` (string | null), `applicationId` (string), `username` (string | null), `password` (string | null), `registryUrl` (string | null) |
-| `application-saveGitProvider` | POST | `customGitBranch` (string | null), `applicationId` (string), `customGitBuildPath` (string | null), `customGitUrl` (string | null), `watchPaths` (array | null), `enableSubmodules`?, `customGitSSHKeyId`? |
+| `application-saveGitProvider` | POST | `applicationId` (string), `customGitBuildPath` (string | null), `customGitUrl` (string | null), `watchPaths` (array | null), `customGitBranch` (string), `enableSubmodules`?, `customGitSSHKeyId`? |
 | `application-disconnectGitProvider` | POST | `applicationId` (string) |
 | `application-markRunning` | POST | `applicationId` (string) |
 | `application-update` | POST | `applicationId` (string), +97 optional |
@@ -199,6 +200,7 @@
 | `compose-disconnectGitProvider` | POST | `composeId` (string) |
 | `compose-move` | POST | `composeId` (string), `targetEnvironmentId` (string) |
 | `compose-processTemplate` | POST | `base64` (string), `composeId` (string) |
+| `compose-previewTemplate` | POST | `base64` (string), `appName` (string), `serverId`? |
 | `compose-import` | POST | `base64` (string), `composeId` (string) |
 | `compose-cancelDeployment` | POST | `composeId` (string) |
 | `compose-search` | GET | +8 optional |
@@ -227,6 +229,7 @@
 | `deployment-allByType` | GET | `id` (string), `type` ("application" | "compose" | "server" | "schedule" | "previewDeployment" | "backup" | "volumeBackup") |
 | `deployment-killProcess` | POST | `deploymentId` (string) |
 | `deployment-removeDeployment` | POST | `deploymentId` (string) |
+| `deployment-readLogs` | GET | `deploymentId` (string), `tail`? |
 
 ## destination
 
@@ -260,12 +263,12 @@
 
 | Tool | Method | Parameters |
 |------|--------|------------|
-| `domain-create` | POST | `host` (string), +14 optional |
+| `domain-create` | POST | `host` (string), +15 optional |
 | `domain-byApplicationId` | GET | `applicationId` (string) |
 | `domain-byComposeId` | GET | `composeId` (string) |
 | `domain-generateDomain` | POST | `appName` (string), `serverId`? |
 | `domain-canGenerateTraefikMeDomains` | GET | `serverId` (string) |
-| `domain-update` | POST | `host` (string), `domainId` (string), +11 optional |
+| `domain-update` | POST | `host` (string), `domainId` (string), +12 optional |
 | `domain-one` | GET | `domainId` (string) |
 | `domain-delete` | POST | `domainId` (string) |
 | `domain-validateDomain` | POST | `domain` (string), `serverIp`? |
@@ -281,6 +284,21 @@
 | `environment-update` | POST | `environmentId` (string), +4 optional |
 | `environment-duplicate` | POST | `environmentId` (string), `name` (string), `description`? |
 | `environment-search` | GET | +6 optional |
+
+## forwardAuth
+
+| Tool | Method | Parameters |
+|------|--------|------------|
+| `forwardAuth-getAuthDomain` | GET | `serverId` (string | null) |
+| `forwardAuth-setAuthDomain` | POST | `serverId` (string | null), `authDomain` (string), `https`?, `certificateType`?, `customCertResolver`? |
+| `forwardAuth-removeAuthDomain` | POST | `serverId` (string | null) |
+| `forwardAuth-listProviders` | GET | None |
+| `forwardAuth-serverStatus` | GET | None |
+| `forwardAuth-deployOnServer` | POST | `serverId` (string | null), `providerId` (string) |
+| `forwardAuth-removeOnServer` | POST | `serverId` (string | null) |
+| `forwardAuth-status` | GET | `domainId` (string) |
+| `forwardAuth-enable` | POST | `domainId` (string) |
+| `forwardAuth-disable` | POST | `domainId` (string) |
 
 ## gitea
 
@@ -616,8 +634,8 @@
 
 | Tool | Method | Parameters |
 |------|--------|------------|
-| `schedule-create` | POST | `name` (string), `cronExpression` (string), `command` (string), +13 optional |
-| `schedule-update` | POST | `scheduleId` (string), `name` (string), `cronExpression` (string), `command` (string), +12 optional |
+| `schedule-create` | POST | `name` (string), `cronExpression` (string), `command` (string), +14 optional |
+| `schedule-update` | POST | `scheduleId` (string), `name` (string), `cronExpression` (string), `command` (string), +13 optional |
 | `schedule-delete` | POST | `scheduleId` (string) |
 | `schedule-list` | GET | `id` (string), `scheduleType` ("application" | "compose" | "server" | "dokploy-server") |
 | `schedule-one` | GET | `scheduleId` (string) |
@@ -636,7 +654,7 @@
 
 | Tool | Method | Parameters |
 |------|--------|------------|
-| `server-create` | POST | `name` (string), `description` (string | null), `ipAddress` (string), `port` (number), `username` (string), `sshKeyId` (string | null), `serverType` ("deploy" | "build") |
+| `server-create` | POST | `name` (string), `description` (string | null), `ipAddress` (string), `port` (number), `username` (string), `sshKeyId` (string | null), `serverType` ("deploy" | "build"), `enableDockerCleanup`? |
 | `server-one` | GET | `serverId` (string) |
 | `server-getDefaultCommand` | GET | `serverId` (string) |
 | `server-all` | GET | None |
@@ -649,7 +667,8 @@
 | `server-security` | GET | `serverId` (string) |
 | `server-setupMonitoring` | POST | `serverId` (string), `metricsConfig` (object) |
 | `server-remove` | POST | `serverId` (string) |
-| `server-update` | POST | `name` (string), `description` (string | null), `serverId` (string), `ipAddress` (string), `port` (number), `username` (string), `sshKeyId` (string | null), `serverType` ("deploy" | "build"), `command`? |
+| `server-update` | POST | `name` (string), `description` (string | null), `serverId` (string), `ipAddress` (string), `port` (number), `username` (string), `sshKeyId` (string | null), `serverType` ("deploy" | "build"), `enableDockerCleanup`?, `command`? |
+| `server-updateBuildsConcurrency` | POST | `serverId` (string), `buildsConcurrency` (integer) |
 | `server-publicIp` | GET | None |
 | `server-getServerTime` | GET | None |
 | `server-getServerMetrics` | GET | `url` (string), `token` (string), `dataPoints` (string) |
@@ -677,6 +696,9 @@
 | `settings-assignDomainServer` | POST | `host` (string), `certificateType` ("letsencrypt" | "none" | "custom"), `letsEncryptEmail`?, `https`? |
 | `settings-cleanSSHPrivateKey` | POST | None |
 | `settings-updateDockerCleanup` | POST | `enableDockerCleanup` (boolean), `serverId`? |
+| `settings-updateRemoteServersOnly` | POST | `remoteServersOnly` (boolean) |
+| `settings-updateBuildsConcurrency` | POST | `buildsConcurrency` (integer) |
+| `settings-updateEnforceSSO` | POST | `enforceSSO` (boolean) |
 | `settings-readTraefikConfig` | GET | None |
 | `settings-updateTraefikConfig` | POST | `traefikConfig` (string) |
 | `settings-readWebServerTraefikConfig` | GET | None |
@@ -727,6 +749,7 @@
 | Tool | Method | Parameters |
 |------|--------|------------|
 | `sso-showSignInWithSSO` | GET | None |
+| `sso-enforceSSO` | GET | None |
 | `sso-listProviders` | GET | None |
 | `sso-getTrustedOrigins` | GET | None |
 | `sso-one` | GET | `providerId` (string) |

--- a/src/generated/openapi.json
+++ b/src/generated/openapi.json
@@ -1292,16 +1292,6 @@
                       }
                     ]
                   },
-                  "branch": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
                   "owner": {
                     "anyOf": [
                       {
@@ -1332,6 +1322,11 @@
                       }
                     ]
                   },
+                  "branch": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9._\\-/]+$"
+                  },
                   "triggerType": {
                     "default": "push",
                     "type": "string",
@@ -1360,10 +1355,10 @@
                 "required": [
                   "applicationId",
                   "repository",
-                  "branch",
                   "owner",
                   "buildPath",
                   "githubId",
+                  "branch",
                   "triggerType"
                 ]
               }
@@ -1448,16 +1443,6 @@
                   "applicationId": {
                     "type": "string"
                   },
-                  "gitlabBranch": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
                   "gitlabBuildPath": {
                     "anyOf": [
                       {
@@ -1518,6 +1503,11 @@
                       }
                     ]
                   },
+                  "gitlabBranch": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9._\\-/]+$"
+                  },
                   "enableSubmodules": {
                     "type": "boolean"
                   },
@@ -1537,13 +1527,13 @@
                 },
                 "required": [
                   "applicationId",
-                  "gitlabBranch",
                   "gitlabBuildPath",
                   "gitlabOwner",
                   "gitlabRepository",
                   "gitlabId",
                   "gitlabProjectId",
-                  "gitlabPathNamespace"
+                  "gitlabPathNamespace",
+                  "gitlabBranch"
                 ]
               }
             }
@@ -1624,16 +1614,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "bitbucketBranch": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
                   "bitbucketBuildPath": {
                     "anyOf": [
                       {
@@ -1687,6 +1667,11 @@
                   "applicationId": {
                     "type": "string"
                   },
+                  "bitbucketBranch": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9._\\-/]+$"
+                  },
                   "enableSubmodules": {
                     "type": "boolean"
                   },
@@ -1705,13 +1690,13 @@
                   }
                 },
                 "required": [
-                  "bitbucketBranch",
                   "bitbucketBuildPath",
                   "bitbucketOwner",
                   "bitbucketRepository",
                   "bitbucketRepositorySlug",
                   "bitbucketId",
-                  "applicationId"
+                  "applicationId",
+                  "bitbucketBranch"
                 ]
               }
             }
@@ -1795,16 +1780,6 @@
                   "applicationId": {
                     "type": "string"
                   },
-                  "giteaBranch": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
                   "giteaBuildPath": {
                     "anyOf": [
                       {
@@ -1845,6 +1820,11 @@
                       }
                     ]
                   },
+                  "giteaBranch": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9._\\-/]+$"
+                  },
                   "enableSubmodules": {
                     "type": "boolean"
                   },
@@ -1864,11 +1844,11 @@
                 },
                 "required": [
                   "applicationId",
-                  "giteaBranch",
                   "giteaBuildPath",
                   "giteaOwner",
                   "giteaRepository",
-                  "giteaId"
+                  "giteaId",
+                  "giteaBranch"
                 ]
               }
             }
@@ -2079,16 +2059,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "customGitBranch": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
                   "applicationId": {
                     "type": "string"
                   },
@@ -2128,6 +2098,11 @@
                   "enableSubmodules": {
                     "type": "boolean"
                   },
+                  "customGitBranch": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9._\\-/]+$"
+                  },
                   "customGitSSHKeyId": {
                     "anyOf": [
                       {
@@ -2140,11 +2115,11 @@
                   }
                 },
                 "required": [
-                  "customGitBranch",
                   "applicationId",
                   "customGitBuildPath",
                   "customGitUrl",
-                  "watchPaths"
+                  "watchPaths",
+                  "customGitBranch"
                 ]
               }
             }
@@ -10504,6 +10479,99 @@
         }
       }
     },
+    "/compose.previewTemplate": {
+      "post": {
+        "operationId": "compose-previewTemplate",
+        "tags": [
+          "compose"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "base64": {
+                    "type": "string"
+                  },
+                  "appName": {
+                    "type": "string"
+                  },
+                  "serverId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "base64",
+                  "appName"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/compose.import": {
       "post": {
         "operationId": "compose-import",
@@ -11627,6 +11695,104 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/deployment.readLogs": {
+      "get": {
+        "operationId": "deployment-readLogs",
+        "tags": [
+          "deployment"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "deploymentId",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "tail",
+            "schema": {
+              "default": 100,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10000
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.NOT_FOUND"
                 }
               }
             }
@@ -13384,7 +13550,8 @@
                   },
                   "destinationPath": {
                     "type": "string",
-                    "minLength": 1
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9.\\-_/]+$"
                   },
                   "serverId": {
                     "type": "string"
@@ -13612,6 +13779,9 @@
                         "type": "null"
                       }
                     ]
+                  },
+                  "forwardAuthEnabled": {
+                    "type": "boolean"
                   }
                 },
                 "required": [
@@ -14156,6 +14326,9 @@
                         "type": "null"
                       }
                     ]
+                  },
+                  "forwardAuthEnabled": {
+                    "type": "boolean"
                   },
                   "domainId": {
                     "type": "string"
@@ -38264,6 +38437,10 @@
                       "deploy",
                       "build"
                     ]
+                  },
+                  "enableDockerCleanup": {
+                    "default": true,
+                    "type": "boolean"
                   }
                 },
                 "required": [
@@ -39490,6 +39667,10 @@
                       "build"
                     ]
                   },
+                  "enableDockerCleanup": {
+                    "default": true,
+                    "type": "boolean"
+                  },
                   "command": {
                     "type": "string"
                   }
@@ -39503,6 +39684,99 @@
                   "username",
                   "sshKeyId",
                   "serverType"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/server.updateBuildsConcurrency": {
+      "post": {
+        "operationId": "server-updateBuildsConcurrency",
+        "tags": [
+          "server"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "serverId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "buildsConcurrency": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100
+                  }
+                },
+                "required": [
+                  "serverId",
+                  "buildsConcurrency"
                 ]
               }
             }
@@ -41276,6 +41550,266 @@
                 },
                 "required": [
                   "enableDockerCleanup"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/settings.updateRemoteServersOnly": {
+      "post": {
+        "operationId": "settings-updateRemoteServersOnly",
+        "tags": [
+          "settings"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "remoteServersOnly": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "remoteServersOnly"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/settings.updateBuildsConcurrency": {
+      "post": {
+        "operationId": "settings-updateBuildsConcurrency",
+        "tags": [
+          "settings"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "buildsConcurrency": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100
+                  }
+                },
+                "required": [
+                  "buildsConcurrency"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/settings.updateEnforceSSO": {
+      "post": {
+        "operationId": "settings-updateEnforceSSO",
+        "tags": [
+          "settings"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "enforceSSO": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "enforceSSO"
                 ]
               }
             }
@@ -50448,6 +50982,83 @@
         }
       }
     },
+    "/sso.enforceSSO": {
+      "get": {
+        "operationId": "sso-enforceSSO",
+        "tags": [
+          "sso"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.NOT_FOUND"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/sso.listProviders": {
       "get": {
         "operationId": "sso-listProviders",
@@ -51739,6 +52350,913 @@
         }
       }
     },
+    "/forwardAuth.getAuthDomain": {
+      "get": {
+        "operationId": "forwardAuth-getAuthDomain",
+        "tags": [
+          "forwardAuth"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "serverId",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.NOT_FOUND"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forwardAuth.setAuthDomain": {
+      "post": {
+        "operationId": "forwardAuth-setAuthDomain",
+        "tags": [
+          "forwardAuth"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "serverId": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "authDomain": {
+                    "type": "string"
+                  },
+                  "https": {
+                    "default": true,
+                    "type": "boolean"
+                  },
+                  "certificateType": {
+                    "default": "letsencrypt",
+                    "type": "string",
+                    "enum": [
+                      "none",
+                      "letsencrypt",
+                      "custom"
+                    ]
+                  },
+                  "customCertResolver": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "serverId",
+                  "authDomain"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forwardAuth.removeAuthDomain": {
+      "post": {
+        "operationId": "forwardAuth-removeAuthDomain",
+        "tags": [
+          "forwardAuth"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "serverId": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "serverId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forwardAuth.listProviders": {
+      "get": {
+        "operationId": "forwardAuth-listProviders",
+        "tags": [
+          "forwardAuth"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.NOT_FOUND"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forwardAuth.serverStatus": {
+      "get": {
+        "operationId": "forwardAuth-serverStatus",
+        "tags": [
+          "forwardAuth"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.NOT_FOUND"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forwardAuth.deployOnServer": {
+      "post": {
+        "operationId": "forwardAuth-deployOnServer",
+        "tags": [
+          "forwardAuth"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "serverId": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "providerId": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "serverId",
+                  "providerId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forwardAuth.removeOnServer": {
+      "post": {
+        "operationId": "forwardAuth-removeOnServer",
+        "tags": [
+          "forwardAuth"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "serverId": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "serverId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forwardAuth.status": {
+      "get": {
+        "operationId": "forwardAuth-status",
+        "tags": [
+          "forwardAuth"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "domainId",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.NOT_FOUND"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forwardAuth.enable": {
+      "post": {
+        "operationId": "forwardAuth-enable",
+        "tags": [
+          "forwardAuth"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "domainId": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "domainId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/forwardAuth.disable": {
+      "post": {
+        "operationId": "forwardAuth-disable",
+        "tags": [
+          "forwardAuth"
+        ],
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "domainId": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "domainId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.BAD_REQUEST"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization not provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.UNAUTHORIZED"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.FORBIDDEN"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error.INTERNAL_SERVER_ERROR"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/whitelabeling.get": {
       "get": {
         "operationId": "whitelabeling-get",
@@ -52916,6 +54434,16 @@
                   "name": {
                     "type": "string"
                   },
+                  "description": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
                   "cronExpression": {
                     "type": "string"
                   },
@@ -52991,7 +54519,7 @@
                       }
                     ]
                   },
-                  "userId": {
+                  "organizationId": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -53109,6 +54637,16 @@
                   "name": {
                     "type": "string"
                   },
+                  "description": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
                   "cronExpression": {
                     "type": "string"
                   },
@@ -53184,7 +54722,7 @@
                       }
                     ]
                   },
-                  "userId": {
+                  "organizationId": {
                     "anyOf": [
                       {
                         "type": "string"

--- a/src/generated/tools.ts
+++ b/src/generated/tools.ts
@@ -1,5 +1,5 @@
 // AUTO-GENERATED FILE — DO NOT EDIT MANUALLY
-// Generated from openapi.json on 2026-04-25
+// Generated from openapi.json on 2026-07-02
 // Run `pnpm generate` to regenerate
 
 import { z } from "zod";
@@ -132,7 +132,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "application",
     method: "POST",
     path: "/application.saveGithubProvider",
-    schema: z.object({ "applicationId": z.string(), "repository": z.union([z.string(), z.null()]), "branch": z.union([z.string(), z.null()]), "owner": z.union([z.string(), z.null()]), "buildPath": z.union([z.string(), z.null()]), "githubId": z.union([z.string(), z.null()]), "triggerType": z.enum(["push","tag"]).default("push"), "enableSubmodules": z.boolean().optional(), "watchPaths": z.union([z.array(z.string()), z.null()]).optional() }),
+    schema: z.object({ "applicationId": z.string(), "repository": z.union([z.string(), z.null()]), "owner": z.union([z.string(), z.null()]), "buildPath": z.union([z.string(), z.null()]), "githubId": z.union([z.string(), z.null()]), "branch": z.string().regex(new RegExp("^[a-zA-Z0-9._\\-/]+$")).min(1), "triggerType": z.enum(["push","tag"]).default("push"), "enableSubmodules": z.boolean().optional(), "watchPaths": z.union([z.array(z.string()), z.null()]).optional() }),
     annotations: {
       title: "Application SaveGithubProvider",
       ...{"idempotentHint":true,"openWorldHint":true},
@@ -144,7 +144,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "application",
     method: "POST",
     path: "/application.saveGitlabProvider",
-    schema: z.object({ "applicationId": z.string(), "gitlabBranch": z.union([z.string(), z.null()]), "gitlabBuildPath": z.union([z.string(), z.null()]), "gitlabOwner": z.union([z.string(), z.null()]), "gitlabRepository": z.union([z.string(), z.null()]), "gitlabId": z.union([z.string(), z.null()]), "gitlabProjectId": z.union([z.number(), z.null()]), "gitlabPathNamespace": z.union([z.string(), z.null()]), "enableSubmodules": z.boolean().optional(), "watchPaths": z.union([z.array(z.string()), z.null()]).optional() }),
+    schema: z.object({ "applicationId": z.string(), "gitlabBuildPath": z.union([z.string(), z.null()]), "gitlabOwner": z.union([z.string(), z.null()]), "gitlabRepository": z.union([z.string(), z.null()]), "gitlabId": z.union([z.string(), z.null()]), "gitlabProjectId": z.union([z.number(), z.null()]), "gitlabPathNamespace": z.union([z.string(), z.null()]), "gitlabBranch": z.string().regex(new RegExp("^[a-zA-Z0-9._\\-/]+$")).min(1), "enableSubmodules": z.boolean().optional(), "watchPaths": z.union([z.array(z.string()), z.null()]).optional() }),
     annotations: {
       title: "Application SaveGitlabProvider",
       ...{"idempotentHint":true,"openWorldHint":true},
@@ -156,7 +156,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "application",
     method: "POST",
     path: "/application.saveBitbucketProvider",
-    schema: z.object({ "bitbucketBranch": z.union([z.string(), z.null()]), "bitbucketBuildPath": z.union([z.string(), z.null()]), "bitbucketOwner": z.union([z.string(), z.null()]), "bitbucketRepository": z.union([z.string(), z.null()]), "bitbucketRepositorySlug": z.union([z.string(), z.null()]), "bitbucketId": z.union([z.string(), z.null()]), "applicationId": z.string(), "enableSubmodules": z.boolean().optional(), "watchPaths": z.union([z.array(z.string()), z.null()]).optional() }),
+    schema: z.object({ "bitbucketBuildPath": z.union([z.string(), z.null()]), "bitbucketOwner": z.union([z.string(), z.null()]), "bitbucketRepository": z.union([z.string(), z.null()]), "bitbucketRepositorySlug": z.union([z.string(), z.null()]), "bitbucketId": z.union([z.string(), z.null()]), "applicationId": z.string(), "bitbucketBranch": z.string().regex(new RegExp("^[a-zA-Z0-9._\\-/]+$")).min(1), "enableSubmodules": z.boolean().optional(), "watchPaths": z.union([z.array(z.string()), z.null()]).optional() }),
     annotations: {
       title: "Application SaveBitbucketProvider",
       ...{"idempotentHint":true,"openWorldHint":true},
@@ -168,7 +168,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "application",
     method: "POST",
     path: "/application.saveGiteaProvider",
-    schema: z.object({ "applicationId": z.string(), "giteaBranch": z.union([z.string(), z.null()]), "giteaBuildPath": z.union([z.string(), z.null()]), "giteaOwner": z.union([z.string(), z.null()]), "giteaRepository": z.union([z.string(), z.null()]), "giteaId": z.union([z.string(), z.null()]), "enableSubmodules": z.boolean().optional(), "watchPaths": z.union([z.array(z.string()), z.null()]).optional() }),
+    schema: z.object({ "applicationId": z.string(), "giteaBuildPath": z.union([z.string(), z.null()]), "giteaOwner": z.union([z.string(), z.null()]), "giteaRepository": z.union([z.string(), z.null()]), "giteaId": z.union([z.string(), z.null()]), "giteaBranch": z.string().regex(new RegExp("^[a-zA-Z0-9._\\-/]+$")).min(1), "enableSubmodules": z.boolean().optional(), "watchPaths": z.union([z.array(z.string()), z.null()]).optional() }),
     annotations: {
       title: "Application SaveGiteaProvider",
       ...{"idempotentHint":true,"openWorldHint":true},
@@ -192,7 +192,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "application",
     method: "POST",
     path: "/application.saveGitProvider",
-    schema: z.object({ "customGitBranch": z.union([z.string(), z.null()]), "applicationId": z.string(), "customGitBuildPath": z.union([z.string(), z.null()]), "customGitUrl": z.union([z.string(), z.null()]), "watchPaths": z.union([z.array(z.string()), z.null()]), "enableSubmodules": z.boolean().optional(), "customGitSSHKeyId": z.union([z.string(), z.null()]).optional() }),
+    schema: z.object({ "applicationId": z.string(), "customGitBuildPath": z.union([z.string(), z.null()]), "customGitUrl": z.union([z.string(), z.null()]), "watchPaths": z.union([z.array(z.string()), z.null()]), "enableSubmodules": z.boolean().optional(), "customGitBranch": z.string().regex(new RegExp("^[a-zA-Z0-9._\\-/]+$")).min(1), "customGitSSHKeyId": z.union([z.string(), z.null()]).optional() }),
     annotations: {
       title: "Application SaveGitProvider",
       ...{"idempotentHint":true,"openWorldHint":true},
@@ -1039,6 +1039,18 @@ export const generatedTools: ToolDefinition[] = [
     },
   },
   {
+    name: "compose-previewTemplate",
+    description: "POST /compose.previewTemplate",
+    tag: "compose",
+    method: "POST",
+    path: "/compose.previewTemplate",
+    schema: z.object({ "base64": z.string(), "appName": z.string(), "serverId": z.string().optional() }),
+    annotations: {
+      title: "Compose PreviewTemplate",
+      ...{"idempotentHint":true,"openWorldHint":true},
+    },
+  },
+  {
     name: "compose-import",
     description: "POST /compose.import",
     tag: "compose",
@@ -1180,6 +1192,18 @@ export const generatedTools: ToolDefinition[] = [
     annotations: {
       title: "Deployment RemoveDeployment",
       ...{"destructiveHint":true,"openWorldHint":true},
+    },
+  },
+  {
+    name: "deployment-readLogs",
+    description: "GET /deployment.readLogs",
+    tag: "deployment",
+    method: "GET",
+    path: "/deployment.readLogs",
+    schema: z.object({ "deploymentId": z.string().min(1), "tail": z.number().int().gte(1).lte(10000).default(100) }),
+    annotations: {
+      title: "Deployment ReadLogs",
+      ...{"readOnlyHint":true,"idempotentHint":true,"openWorldHint":true},
     },
   },
   {
@@ -1404,7 +1428,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "domain",
     method: "POST",
     path: "/domain.create",
-    schema: z.object({ "host": z.string().min(1), "path": z.union([z.string().min(1), z.null()]).optional(), "port": z.union([z.number().gte(1).lte(65535), z.null()]).optional(), "customEntrypoint": z.union([z.string(), z.null()]).optional(), "https": z.boolean().optional(), "applicationId": z.union([z.string(), z.null()]).optional(), "certificateType": z.enum(["letsencrypt","none","custom"]).optional(), "customCertResolver": z.union([z.string(), z.null()]).optional(), "composeId": z.union([z.string(), z.null()]).optional(), "serviceName": z.union([z.string(), z.null()]).optional(), "domainType": z.union([z.enum(["compose","application","preview"]), z.null()]).optional(), "previewDeploymentId": z.union([z.string(), z.null()]).optional(), "internalPath": z.union([z.string(), z.null()]).optional(), "stripPath": z.boolean().optional(), "middlewares": z.union([z.array(z.string()), z.null()]).optional() }),
+    schema: z.object({ "host": z.string().min(1), "path": z.union([z.string().min(1), z.null()]).optional(), "port": z.union([z.number().gte(1).lte(65535), z.null()]).optional(), "customEntrypoint": z.union([z.string(), z.null()]).optional(), "https": z.boolean().optional(), "applicationId": z.union([z.string(), z.null()]).optional(), "certificateType": z.enum(["letsencrypt","none","custom"]).optional(), "customCertResolver": z.union([z.string(), z.null()]).optional(), "composeId": z.union([z.string(), z.null()]).optional(), "serviceName": z.union([z.string(), z.null()]).optional(), "domainType": z.union([z.enum(["compose","application","preview"]), z.null()]).optional(), "previewDeploymentId": z.union([z.string(), z.null()]).optional(), "internalPath": z.union([z.string(), z.null()]).optional(), "stripPath": z.boolean().optional(), "middlewares": z.union([z.array(z.string()), z.null()]).optional(), "forwardAuthEnabled": z.boolean().optional() }),
     annotations: {
       title: "Domain Create",
       ...{"openWorldHint":true},
@@ -1464,7 +1488,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "domain",
     method: "POST",
     path: "/domain.update",
-    schema: z.object({ "host": z.string().min(1), "path": z.union([z.string().min(1), z.null()]).optional(), "port": z.union([z.number().gte(1).lte(65535), z.null()]).optional(), "customEntrypoint": z.union([z.string(), z.null()]).optional(), "https": z.boolean().optional(), "certificateType": z.enum(["letsencrypt","none","custom"]).optional(), "customCertResolver": z.union([z.string(), z.null()]).optional(), "serviceName": z.union([z.string(), z.null()]).optional(), "domainType": z.union([z.enum(["compose","application","preview"]), z.null()]).optional(), "internalPath": z.union([z.string(), z.null()]).optional(), "stripPath": z.boolean().optional(), "middlewares": z.union([z.array(z.string()), z.null()]).optional(), "domainId": z.string() }),
+    schema: z.object({ "host": z.string().min(1), "path": z.union([z.string().min(1), z.null()]).optional(), "port": z.union([z.number().gte(1).lte(65535), z.null()]).optional(), "customEntrypoint": z.union([z.string(), z.null()]).optional(), "https": z.boolean().optional(), "certificateType": z.enum(["letsencrypt","none","custom"]).optional(), "customCertResolver": z.union([z.string(), z.null()]).optional(), "serviceName": z.union([z.string(), z.null()]).optional(), "domainType": z.union([z.enum(["compose","application","preview"]), z.null()]).optional(), "internalPath": z.union([z.string(), z.null()]).optional(), "stripPath": z.boolean().optional(), "middlewares": z.union([z.array(z.string()), z.null()]).optional(), "forwardAuthEnabled": z.boolean().optional(), "domainId": z.string() }),
     annotations: {
       title: "Domain Update",
       ...{"idempotentHint":true,"openWorldHint":true},
@@ -3888,7 +3912,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "server",
     method: "POST",
     path: "/server.create",
-    schema: z.object({ "name": z.string().min(1), "description": z.union([z.string(), z.null()]), "ipAddress": z.string(), "port": z.number(), "username": z.string(), "sshKeyId": z.union([z.string(), z.null()]), "serverType": z.enum(["deploy","build"]) }),
+    schema: z.object({ "name": z.string().min(1), "description": z.union([z.string(), z.null()]), "ipAddress": z.string(), "port": z.number(), "username": z.string(), "sshKeyId": z.union([z.string(), z.null()]), "serverType": z.enum(["deploy","build"]), "enableDockerCleanup": z.boolean().default(true) }),
     annotations: {
       title: "Server Create",
       ...{"openWorldHint":true},
@@ -4044,9 +4068,21 @@ export const generatedTools: ToolDefinition[] = [
     tag: "server",
     method: "POST",
     path: "/server.update",
-    schema: z.object({ "name": z.string().min(1), "description": z.union([z.string(), z.null()]), "serverId": z.string().min(1), "ipAddress": z.string(), "port": z.number(), "username": z.string(), "sshKeyId": z.union([z.string(), z.null()]), "serverType": z.enum(["deploy","build"]), "command": z.string().optional() }),
+    schema: z.object({ "name": z.string().min(1), "description": z.union([z.string(), z.null()]), "serverId": z.string().min(1), "ipAddress": z.string(), "port": z.number(), "username": z.string(), "sshKeyId": z.union([z.string(), z.null()]), "serverType": z.enum(["deploy","build"]), "enableDockerCleanup": z.boolean().default(true), "command": z.string().optional() }),
     annotations: {
       title: "Server Update",
+      ...{"idempotentHint":true,"openWorldHint":true},
+    },
+  },
+  {
+    name: "server-updateBuildsConcurrency",
+    description: "POST /server.updateBuildsConcurrency",
+    tag: "server",
+    method: "POST",
+    path: "/server.updateBuildsConcurrency",
+    schema: z.object({ "serverId": z.string().min(1), "buildsConcurrency": z.number().int().gte(1).lte(100) }),
+    annotations: {
+      title: "Server UpdateBuildsConcurrency",
       ...{"idempotentHint":true,"openWorldHint":true},
     },
   },
@@ -4311,6 +4347,42 @@ export const generatedTools: ToolDefinition[] = [
     schema: z.object({ "enableDockerCleanup": z.boolean(), "serverId": z.string().optional() }),
     annotations: {
       title: "Settings UpdateDockerCleanup",
+      ...{"idempotentHint":true,"openWorldHint":true},
+    },
+  },
+  {
+    name: "settings-updateRemoteServersOnly",
+    description: "POST /settings.updateRemoteServersOnly",
+    tag: "settings",
+    method: "POST",
+    path: "/settings.updateRemoteServersOnly",
+    schema: z.object({ "remoteServersOnly": z.boolean() }),
+    annotations: {
+      title: "Settings UpdateRemoteServersOnly",
+      ...{"idempotentHint":true,"openWorldHint":true},
+    },
+  },
+  {
+    name: "settings-updateBuildsConcurrency",
+    description: "POST /settings.updateBuildsConcurrency",
+    tag: "settings",
+    method: "POST",
+    path: "/settings.updateBuildsConcurrency",
+    schema: z.object({ "buildsConcurrency": z.number().int().gte(1).lte(100) }),
+    annotations: {
+      title: "Settings UpdateBuildsConcurrency",
+      ...{"idempotentHint":true,"openWorldHint":true},
+    },
+  },
+  {
+    name: "settings-updateEnforceSSO",
+    description: "POST /settings.updateEnforceSSO",
+    tag: "settings",
+    method: "POST",
+    path: "/settings.updateEnforceSSO",
+    schema: z.object({ "enforceSSO": z.boolean() }),
+    annotations: {
+      title: "Settings UpdateEnforceSSO",
       ...{"idempotentHint":true,"openWorldHint":true},
     },
   },
@@ -5563,6 +5635,18 @@ export const generatedTools: ToolDefinition[] = [
     },
   },
   {
+    name: "sso-enforceSSO",
+    description: "GET /sso.enforceSSO",
+    tag: "sso",
+    method: "GET",
+    path: "/sso.enforceSSO",
+    schema: z.object({}),
+    annotations: {
+      title: "Sso EnforceSSO",
+      ...{"readOnlyHint":true,"idempotentHint":true,"openWorldHint":true},
+    },
+  },
+  {
     name: "sso-listProviders",
     description: "GET /sso.listProviders",
     tag: "sso",
@@ -5667,6 +5751,126 @@ export const generatedTools: ToolDefinition[] = [
     schema: z.object({ "oldOrigin": z.string().min(1), "newOrigin": z.string().min(1) }),
     annotations: {
       title: "Sso UpdateTrustedOrigin",
+      ...{"idempotentHint":true,"openWorldHint":true},
+    },
+  },
+  {
+    name: "forwardAuth-getAuthDomain",
+    description: "GET /forwardAuth.getAuthDomain",
+    tag: "forwardAuth",
+    method: "GET",
+    path: "/forwardAuth.getAuthDomain",
+    schema: z.object({ "serverId": z.union([z.string(), z.null()]) }),
+    annotations: {
+      title: "ForwardAuth GetAuthDomain",
+      ...{"readOnlyHint":true,"idempotentHint":true,"openWorldHint":true},
+    },
+  },
+  {
+    name: "forwardAuth-setAuthDomain",
+    description: "POST /forwardAuth.setAuthDomain",
+    tag: "forwardAuth",
+    method: "POST",
+    path: "/forwardAuth.setAuthDomain",
+    schema: z.object({ "serverId": z.union([z.string(), z.null()]), "authDomain": z.string(), "https": z.boolean().default(true), "certificateType": z.enum(["none","letsencrypt","custom"]).default("letsencrypt"), "customCertResolver": z.string().optional() }),
+    annotations: {
+      title: "ForwardAuth SetAuthDomain",
+      ...{"idempotentHint":true,"openWorldHint":true},
+    },
+  },
+  {
+    name: "forwardAuth-removeAuthDomain",
+    description: "POST /forwardAuth.removeAuthDomain",
+    tag: "forwardAuth",
+    method: "POST",
+    path: "/forwardAuth.removeAuthDomain",
+    schema: z.object({ "serverId": z.union([z.string(), z.null()]) }),
+    annotations: {
+      title: "ForwardAuth RemoveAuthDomain",
+      ...{"destructiveHint":true,"openWorldHint":true},
+    },
+  },
+  {
+    name: "forwardAuth-listProviders",
+    description: "GET /forwardAuth.listProviders",
+    tag: "forwardAuth",
+    method: "GET",
+    path: "/forwardAuth.listProviders",
+    schema: z.object({}),
+    annotations: {
+      title: "ForwardAuth ListProviders",
+      ...{"readOnlyHint":true,"idempotentHint":true,"openWorldHint":true},
+    },
+  },
+  {
+    name: "forwardAuth-serverStatus",
+    description: "GET /forwardAuth.serverStatus",
+    tag: "forwardAuth",
+    method: "GET",
+    path: "/forwardAuth.serverStatus",
+    schema: z.object({}),
+    annotations: {
+      title: "ForwardAuth ServerStatus",
+      ...{"readOnlyHint":true,"idempotentHint":true,"openWorldHint":true},
+    },
+  },
+  {
+    name: "forwardAuth-deployOnServer",
+    description: "POST /forwardAuth.deployOnServer",
+    tag: "forwardAuth",
+    method: "POST",
+    path: "/forwardAuth.deployOnServer",
+    schema: z.object({ "serverId": z.union([z.string(), z.null()]), "providerId": z.string().min(1) }),
+    annotations: {
+      title: "ForwardAuth DeployOnServer",
+      ...{"idempotentHint":true,"openWorldHint":true},
+    },
+  },
+  {
+    name: "forwardAuth-removeOnServer",
+    description: "POST /forwardAuth.removeOnServer",
+    tag: "forwardAuth",
+    method: "POST",
+    path: "/forwardAuth.removeOnServer",
+    schema: z.object({ "serverId": z.union([z.string(), z.null()]) }),
+    annotations: {
+      title: "ForwardAuth RemoveOnServer",
+      ...{"destructiveHint":true,"openWorldHint":true},
+    },
+  },
+  {
+    name: "forwardAuth-status",
+    description: "GET /forwardAuth.status",
+    tag: "forwardAuth",
+    method: "GET",
+    path: "/forwardAuth.status",
+    schema: z.object({ "domainId": z.string().min(1) }),
+    annotations: {
+      title: "ForwardAuth Status",
+      ...{"readOnlyHint":true,"idempotentHint":true,"openWorldHint":true},
+    },
+  },
+  {
+    name: "forwardAuth-enable",
+    description: "POST /forwardAuth.enable",
+    tag: "forwardAuth",
+    method: "POST",
+    path: "/forwardAuth.enable",
+    schema: z.object({ "domainId": z.string().min(1) }),
+    annotations: {
+      title: "ForwardAuth Enable",
+      ...{"idempotentHint":true,"openWorldHint":true},
+    },
+  },
+  {
+    name: "forwardAuth-disable",
+    description: "POST /forwardAuth.disable",
+    tag: "forwardAuth",
+    method: "POST",
+    path: "/forwardAuth.disable",
+    schema: z.object({ "domainId": z.string().min(1) }),
+    annotations: {
+      title: "ForwardAuth Disable",
       ...{"idempotentHint":true,"openWorldHint":true},
     },
   },
@@ -5808,7 +6012,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "schedule",
     method: "POST",
     path: "/schedule.create",
-    schema: z.object({ "scheduleId": z.string().optional(), "name": z.string(), "cronExpression": z.string(), "appName": z.string().optional(), "serviceName": z.union([z.string(), z.null()]).optional(), "shellType": z.enum(["bash","sh"]).optional(), "scheduleType": z.enum(["application","compose","server","dokploy-server"]).optional(), "command": z.string(), "script": z.union([z.string(), z.null()]).optional(), "applicationId": z.union([z.string(), z.null()]).optional(), "composeId": z.union([z.string(), z.null()]).optional(), "serverId": z.union([z.string(), z.null()]).optional(), "userId": z.union([z.string(), z.null()]).optional(), "enabled": z.boolean().optional(), "timezone": z.union([z.string(), z.null()]).optional(), "createdAt": z.string().optional() }),
+    schema: z.object({ "scheduleId": z.string().optional(), "name": z.string(), "description": z.union([z.string(), z.null()]).optional(), "cronExpression": z.string(), "appName": z.string().optional(), "serviceName": z.union([z.string(), z.null()]).optional(), "shellType": z.enum(["bash","sh"]).optional(), "scheduleType": z.enum(["application","compose","server","dokploy-server"]).optional(), "command": z.string(), "script": z.union([z.string(), z.null()]).optional(), "applicationId": z.union([z.string(), z.null()]).optional(), "composeId": z.union([z.string(), z.null()]).optional(), "serverId": z.union([z.string(), z.null()]).optional(), "organizationId": z.union([z.string(), z.null()]).optional(), "enabled": z.boolean().optional(), "timezone": z.union([z.string(), z.null()]).optional(), "createdAt": z.string().optional() }),
     annotations: {
       title: "Schedule Create",
       ...{"openWorldHint":true},
@@ -5820,7 +6024,7 @@ export const generatedTools: ToolDefinition[] = [
     tag: "schedule",
     method: "POST",
     path: "/schedule.update",
-    schema: z.object({ "scheduleId": z.string().min(1), "name": z.string(), "cronExpression": z.string(), "appName": z.string().optional(), "serviceName": z.union([z.string(), z.null()]).optional(), "shellType": z.enum(["bash","sh"]).optional(), "scheduleType": z.enum(["application","compose","server","dokploy-server"]).optional(), "command": z.string(), "script": z.union([z.string(), z.null()]).optional(), "applicationId": z.union([z.string(), z.null()]).optional(), "composeId": z.union([z.string(), z.null()]).optional(), "serverId": z.union([z.string(), z.null()]).optional(), "userId": z.union([z.string(), z.null()]).optional(), "enabled": z.boolean().optional(), "timezone": z.union([z.string(), z.null()]).optional(), "createdAt": z.string().optional() }),
+    schema: z.object({ "scheduleId": z.string().min(1), "name": z.string(), "description": z.union([z.string(), z.null()]).optional(), "cronExpression": z.string(), "appName": z.string().optional(), "serviceName": z.union([z.string(), z.null()]).optional(), "shellType": z.enum(["bash","sh"]).optional(), "scheduleType": z.enum(["application","compose","server","dokploy-server"]).optional(), "command": z.string(), "script": z.union([z.string(), z.null()]).optional(), "applicationId": z.union([z.string(), z.null()]).optional(), "composeId": z.union([z.string(), z.null()]).optional(), "serverId": z.union([z.string(), z.null()]).optional(), "organizationId": z.union([z.string(), z.null()]).optional(), "enabled": z.boolean().optional(), "timezone": z.union([z.string(), z.null()]).optional(), "createdAt": z.string().optional() }),
     annotations: {
       title: "Schedule Update",
       ...{"idempotentHint":true,"openWorldHint":true},

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,6 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock apiClient before server.ts is imported — it calls getClientConfig() at
 // module level which requires DOKPLOY_URL/DOKPLOY_API_KEY env vars.
@@ -10,15 +10,44 @@ vi.mock("./utils/apiClient.js", () => ({
   clearAuthToken: vi.fn(),
 }));
 
+const { default: apiClient } = await import("./utils/apiClient.js");
 const { createServer } = await import("./server.js");
 
 describe("MCP server tools/list", () => {
-  async function getToolList() {
+  const originalDokployUrl = process.env.DOKPLOY_URL;
+  const originalDokployApiKey = process.env.DOKPLOY_API_KEY;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.DOKPLOY_URL = "https://dokploy.example";
+    process.env.DOKPLOY_API_KEY = "test-api-key";
+  });
+
+  afterEach(() => {
+    if (originalDokployUrl === undefined) {
+      delete process.env.DOKPLOY_URL;
+    } else {
+      process.env.DOKPLOY_URL = originalDokployUrl;
+    }
+
+    if (originalDokployApiKey === undefined) {
+      delete process.env.DOKPLOY_API_KEY;
+    } else {
+      process.env.DOKPLOY_API_KEY = originalDokployApiKey;
+    }
+  });
+
+  async function createConnectedClient() {
     const server = createServer();
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await server.connect(serverTransport);
     const client = new Client({ name: "test-client", version: "1.0.0" });
     await client.connect(clientTransport);
+    return client;
+  }
+
+  async function getToolList() {
+    const client = await createConnectedClient();
     const { tools } = await client.listTools();
     await client.close();
     return tools;
@@ -29,14 +58,70 @@ describe("MCP server tools/list", () => {
     expect(tools.length).toBeGreaterThan(0);
   });
 
+  it("exposes deployment-readLogs for schedule deployment log inspection", async () => {
+    const tools = await getToolList();
+    const tool = tools.find(({ name }) => name === "deployment-readLogs");
+
+    expect(tool).toBeDefined();
+    expect(tool?.description).toBe("GET /deployment.readLogs");
+
+    const schema = tool?.inputSchema as Record<string, unknown>;
+    const properties = schema.properties as Record<string, Record<string, unknown>>;
+    const required = schema.required as string[];
+
+    expect(properties.deploymentId).toMatchObject({
+      type: "string",
+      minLength: 1,
+    });
+    expect(properties.tail).toMatchObject({
+      type: "integer",
+      minimum: 1,
+      maximum: 10000,
+      default: 100,
+    });
+    expect(required).toContain("deploymentId");
+  });
+
+  it("routes deployment-readLogs calls to the deployment log API endpoint", async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: "schedule stdout\nschedule stderr",
+    });
+
+    const client = await createConnectedClient();
+    const result = await client.callTool({
+      name: "deployment-readLogs",
+      arguments: {
+        deploymentId: "dep_test",
+        tail: 25,
+      },
+    });
+    await client.close();
+
+    expect(apiClient.get).toHaveBeenCalledWith("/deployment.readLogs", {
+      params: {
+        deploymentId: "dep_test",
+        tail: 25,
+      },
+    });
+
+    const content = result.content[0];
+    expect(content.type).toBe("text");
+    const parsed = JSON.parse(content.type === "text" ? content.text : "");
+
+    expect(parsed).toEqual({
+      success: true,
+      message: "deployment-readLogs completed successfully",
+      data: "schedule stdout\nschedule stderr",
+    });
+  });
+
   it("every tool inputSchema has $schema set to draft 2020-12", async () => {
     const tools = await getToolList();
     for (const tool of tools) {
       const schema = tool.inputSchema as Record<string, unknown>;
-      expect(
-        schema.$schema,
-        `Tool "${tool.name}" is missing $schema or has wrong draft`,
-      ).toBe("https://json-schema.org/draft/2020-12/schema");
+      expect(schema.$schema, `Tool "${tool.name}" is missing $schema or has wrong draft`).toBe(
+        "https://json-schema.org/draft/2020-12/schema",
+      );
     }
   });
 
@@ -60,7 +145,10 @@ describe("MCP server tools/list", () => {
 
     for (const tool of tools) {
       const found = findNestedSchemaKeys(tool.inputSchema);
-      expect(found, `Tool "${tool.name}" has nested $schema keys at: ${found.join(", ")}`).toHaveLength(0);
+      expect(
+        found,
+        `Tool "${tool.name}" has nested $schema keys at: ${found.join(", ")}`,
+      ).toHaveLength(0);
     }
   });
 


### PR DESCRIPTION
## Summary

Closes #53.

This syncs the generated Dokploy OpenAPI artifacts with the current published spec so the MCP server exposes `deployment-readLogs`.

That gives schedule users a direct way to read the deployment log created by a manual schedule run:

- `deployment-readLogs` is now included in `tools/list`.
- `deployment-readLogs` routes `tools/call` to `GET /deployment.readLogs` with `deploymentId` and optional `tail`.
- `TOOLS.md` now documents the generated deployment log reader.

The sync also pulls in the other endpoints currently present in the published Dokploy OpenAPI spec but missing from `src/generated/openapi.json`.

## Testing

- `corepack pnpm exec vitest run src/server.test.ts --reporter=verbose`
- `corepack pnpm run lint`
- `corepack pnpm run type-check`
- `corepack pnpm run test`
- `corepack pnpm run build`
- `git diff --check`

Note: `pnpm run lint` passes with the existing `src/utils/responseFormatter.ts` static-only class warning.

## QA

Independent Agent Flow QA rechecked the final diff and returned `pass`.

Live Dokploy schedule execution was not tested because this PR does not use a real Dokploy instance, secrets, Docker, or deployment infrastructure.
