### PR TITLE
fix: strip unsupported regex patterns from tool schemas

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -33,10 +33,9 @@ describe("MCP server tools/list", () => {
     const tools = await getToolList();
     for (const tool of tools) {
       const schema = tool.inputSchema as Record<string, unknown>;
-      expect(
-        schema.$schema,
-        `Tool "${tool.name}" is missing $schema or has wrong draft`,
-      ).toBe("https://json-schema.org/draft/2020-12/schema");
+      expect(schema.$schema, `Tool "${tool.name}" is missing $schema or has wrong draft`).toBe(
+        "https://json-schema.org/draft/2020-12/schema",
+      );
     }
   });
 
@@ -60,7 +59,40 @@ describe("MCP server tools/list", () => {
 
     for (const tool of tools) {
       const found = findNestedSchemaKeys(tool.inputSchema);
-      expect(found, `Tool "${tool.name}" has nested $schema keys at: ${found.join(", ")}`).toHaveLength(0);
+      expect(
+        found,
+        `Tool "${tool.name}" has nested $schema keys at: ${found.join(", ")}`,
+      ).toHaveLength(0);
+    }
+  });
+
+  it("no tool inputSchema exposes regex lookaround patterns", async () => {
+    const tools = await getToolList();
+
+    function findLookaroundPatterns(obj: unknown, path = ""): string[] {
+      if (obj === null || typeof obj !== "object") return [];
+      if (Array.isArray(obj)) {
+        return obj.flatMap((item, i) => findLookaroundPatterns(item, `${path}[${i}]`));
+      }
+
+      const record = obj as Record<string, unknown>;
+      const found: string[] = [];
+      for (const [key, value] of Object.entries(record)) {
+        const currentPath = path ? `${path}.${key}` : key;
+        if (key === "pattern" && typeof value === "string" && /\(\?<?[=!]/.test(value)) {
+          found.push(currentPath);
+        }
+        found.push(...findLookaroundPatterns(value, currentPath));
+      }
+      return found;
+    }
+
+    for (const tool of tools) {
+      const found = findLookaroundPatterns(tool.inputSchema);
+      expect(
+        found,
+        `Tool "${tool.name}" exposes provider-incompatible lookaround patterns at: ${found.join(", ")}`,
+      ).toHaveLength(0);
     }
   });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,6 +51,27 @@ function stripNestedSchemaKeys(value: unknown): void {
   }
 }
 
+function usesUnsupportedRegexSyntax(pattern: unknown): boolean {
+  return typeof pattern === "string" && /\(\?<?[=!]/.test(pattern);
+}
+
+function stripUnsupportedRegexPatterns(value: unknown): void {
+  if (value === null || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const item of value) stripUnsupportedRegexPatterns(item);
+    return;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (usesUnsupportedRegexSyntax(record.pattern)) {
+    delete record.pattern;
+  }
+
+  for (const child of Object.values(record)) {
+    stripUnsupportedRegexPatterns(child);
+  }
+}
+
 // Claude's API requires JSON Schema draft 2020-12. The MCP SDK's built-in
 // Zod→JSON Schema converter emits draft-07 by default, which causes a 400
 // error on tools/list. We bypass the SDK's auto-generated handler by
@@ -63,6 +84,7 @@ function toDraft2020_12JsonSchema(schema: ZodObject<ZodRawShape>): Record<string
   }) as Record<string, unknown>;
 
   stripNestedSchemaKeys(result);
+  stripUnsupportedRegexPatterns(result);
   result.$schema = JSON_SCHEMA_2020_12;
   return result;
 }


### PR DESCRIPTION
## Summary
- remove provider-incompatible regex lookaround `pattern` fields from MCP `tools/list` JSON schemas
- keep the existing Zod runtime validators unchanged for actual tool calls
- add a regression test that walks every exposed tool schema and fails on lookaround patterns

Fixes #45.

## Verification
- `npm exec --yes pnpm@10 -- install --frozen-lockfile`
- `npm exec --yes pnpm@10 -- test src/server.test.ts`
- `npm exec --yes pnpm@10 -- format`
- `npm exec --yes pnpm@10 -- lint`
- `npm exec --yes pnpm@10 -- test`
- `npm exec --yes pnpm@10 -- type-check`
- `git diff --check`

Note: `biome check` still reports the existing `ResponseFormatter` static-only class warning, but exits successfully after formatting.