### PR TITLE
fix: make docker compose build pass from fresh clone

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -96,4 +96,3 @@ Makefile
 # Package locks (can be regenerated)
 package-lock.json
 yarn.lock
-pnpm-lock.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM node:lts-alpine AS builder
 WORKDIR /app
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 # Copy package and configuration
-COPY package.json pnpm-lock.yaml tsconfig.json ./
+COPY package.json pnpm-lock.yaml tsconfig.json .npmrc ./
 
 # Copy source code
 COPY src ./src
@@ -19,13 +19,13 @@ FROM node:lts-alpine
 WORKDIR /app
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 # Copy built artifacts
 COPY --from=builder /app/build ./build
 
 # Copy package.json and lockfile for production install
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml .npmrc ./
 
 # Install only production dependencies
 RUN pnpm install --prod --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
## What this fixes
This PR fixes docker compose build failures from a clean checkout.

### Root causes
1. .dockerignore excluded pnpm-lock.yaml, but Dockerfile requires it in COPY commands.
2. Dockerfile used pnpm@latest, which now resolves to v11 and breaks install in this repo with ERR_PNPM_IGNORED_BUILDS.

## Changes
- Remove pnpm-lock.yaml from .dockerignore
- Pin pnpm in Dockerfile to 10.33.0 in both stages
- Copy .npmrc into builder and runtime stages so pnpm settings are consistently applied

## Validation
- docker compose build --no-cache succeeds locally
- docker compose up -d starts both services successfully

Closes #59