### PR TITLE
fix: migrate esbuild build approval to pnpm 11

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -96,4 +96,3 @@ Makefile
 # Package locks (can be regenerated)
 package-lock.json
 yarn.lock
-pnpm-lock.yaml

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-onlyBuiltDependencies[]=esbuild

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
 # Copy package and configuration
-COPY package.json pnpm-lock.yaml tsconfig.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 
 # Copy source code
 COPY src ./src
@@ -25,7 +25,7 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 COPY --from=builder /app/build ./build
 
 # Copy package.json and lockfile for production install
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Install only production dependencies
 RUN pnpm install --prod --frozen-lockfile --ignore-scripts

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Summary

- Migrate the esbuild build approval from the deprecated `onlyBuiltDependencies` setting to pnpm v11's `allowBuilds` configuration.
- Include `pnpm-lock.yaml` and `pnpm-workspace.yaml` in the Docker build context and image stages.
- Keep `pnpm@latest` instead of pinning the Docker build to an older pnpm release.

## Root cause

A clean `docker compose build` currently fails in two stages:

1. `.dockerignore` excludes `pnpm-lock.yaml`, even though the Dockerfile copies it.
2. Once the lockfile is available, pnpm v11 rejects the unapproved `esbuild@0.27.7` postinstall script with `ERR_PNPM_IGNORED_BUILDS`.

The existing `.npmrc` uses `onlyBuiltDependencies`, which is deprecated in pnpm v11. This change replaces it with the supported project-level configuration:

```yaml
allowBuilds:
  esbuild: true
```

## Changes

- Stop excluding `pnpm-lock.yaml` from the Docker build context.
- Replace `.npmrc` with `pnpm-workspace.yaml` and explicitly allow the esbuild build script.
- Copy `pnpm-workspace.yaml` into both Docker stages before dependency installation.

## Validation

- `docker compose build --no-cache`
  - pnpm `11.13.1`
  - esbuild postinstall completed successfully
  - both HTTP and stdio images built successfully
- `docker compose up -d`
  - both services started and reported healthy
- `pnpm test`: 25 tests passed
- `pnpm run type-check`: passed
- `git diff --check`: passed
- `pnpm run lint`: reports an existing formatting error in `src/server.test.ts` and an existing warning in `src/utils/responseFormatter.ts`; neither file is changed by this PR

Closes #59

Alternative to #60: this fixes the same Docker build failure by migrating the project configuration to pnpm v11 instead of pinning pnpm to v10.


Related core workflow workaround: Dokploy/dokploy#4839