### PR TITLE
fix: redact provider-prefixed secret fields in API responses

### DIFF
--- a/src/utils/redactSensitive.test.ts
+++ b/src/utils/redactSensitive.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_REDACTED_FIELDS, redactSensitive } from "./redactSensitive.js";
+
+const redact = <T>(data: T) => redactSensitive(data, DEFAULT_REDACTED_FIELDS);
+
+describe("redactSensitive", () => {
+  it("redacts exact default field names", () => {
+    const result = redact({ password: "hunter2", env: "KEY=value", apiKey: "sk-123" });
+    expect(result).toEqual({ password: "[REDACTED]", env: "[REDACTED]", apiKey: "[REDACTED]" });
+  });
+
+  it("redacts provider-prefixed secret fields (issue #65)", () => {
+    const result = redact({
+      githubPrivateKey: "-----BEGIN RSA PRIVATE KEY-----",
+      githubClientSecret: "ghs_abc",
+      githubWebhookSecret: "whsec_abc",
+      gitlabAccessToken: "glpat-abc",
+      awsSecretAccessKey: "aws-abc",
+    });
+    expect(result).toEqual({
+      githubPrivateKey: "[REDACTED]",
+      githubClientSecret: "[REDACTED]",
+      githubWebhookSecret: "[REDACTED]",
+      gitlabAccessToken: "[REDACTED]",
+      awsSecretAccessKey: "[REDACTED]",
+    });
+  });
+
+  it("matches case-insensitively", () => {
+    const result = redact({ PASSWORD: "x", GithubPrivateKey: "y" });
+    expect(result).toEqual({ PASSWORD: "[REDACTED]", GithubPrivateKey: "[REDACTED]" });
+  });
+
+  it("preserves null and undefined values in sensitive fields", () => {
+    const result = redact({ password: null, token: undefined });
+    expect(result).toEqual({ password: null, token: undefined });
+  });
+
+  it("redacts inside nested objects and arrays", () => {
+    const result = redact({
+      apps: [{ name: "web", env: "SECRET=1" }, { config: { registryPassword: "p" } }],
+    });
+    expect(result).toEqual({
+      apps: [
+        { name: "web", env: "[REDACTED]" },
+        { config: { registryPassword: "[REDACTED]" } },
+      ],
+    });
+  });
+
+  it("leaves non-sensitive fields untouched", () => {
+    const data = { appName: "web", domain: "example.com", port: 3000, https: true };
+    expect(redact(data)).toEqual(data);
+  });
+
+  it("returns data unchanged when the field list is empty", () => {
+    const data = { password: "visible" };
+    expect(redactSensitive(data, [])).toBe(data);
+  });
+
+  it("supports custom field lists via suffix match", () => {
+    const result = redactSensitive({ myCustomField: "x", other: "y" }, ["customField"]);
+    expect(result).toEqual({ myCustomField: "[REDACTED]", other: "y" });
+  });
+
+  it("does not hang on circular structures", () => {
+    const data: Record<string, unknown> = { name: "a" };
+    data.self = data;
+    expect(() => redact(data)).not.toThrow();
+  });
+
+  it("drops prototype-pollution keys", () => {
+    const data = JSON.parse('{"__proto__": {"polluted": true}, "name": "safe"}');
+    const result = redact(data) as Record<string, unknown>;
+    expect(Object.keys(result)).toEqual(["name"]);
+  });
+
+  // Known, accepted collateral of suffix matching: flag-style keys that end in a
+  // sensitive word (e.g. isSecret) are also redacted. Erring toward redaction is
+  // intentional for security-sensitive output.
+  it("redacts flag-like keys ending in a sensitive suffix", () => {
+    const result = redact({ isSecret: true });
+    expect(result).toEqual({ isSecret: "[REDACTED]" });
+  });
+});

--- a/src/utils/redactSensitive.ts
+++ b/src/utils/redactSensitive.ts
@@ -44,8 +44,8 @@ const REDACTED_PLACEHOLDER = "[REDACTED]";
 
 export function redactSensitive<T>(data: T, fields: string[]): T {
   if (fields.length === 0) return data;
-  const lowered = new Set(fields.map((f) => f.toLowerCase()));
-  return walk(data, lowered, new WeakSet()) as T;
+  const suffixes = fields.map((f) => f.toLowerCase());
+  return walk(data, suffixes, new WeakSet()) as T;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -54,11 +54,11 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return proto === Object.prototype || proto === null;
 }
 
-function walk(value: unknown, fields: Set<string>, seen: WeakSet<object>): unknown {
+function walk(value: unknown, suffixes: string[], seen: WeakSet<object>): unknown {
   if (Array.isArray(value)) {
     if (seen.has(value)) return value;
     seen.add(value);
-    return value.map((item) => walk(item, fields, seen));
+    return value.map((item) => walk(item, suffixes, seen));
   }
   if (isPlainObject(value)) {
     if (seen.has(value)) return value;
@@ -67,10 +67,10 @@ function walk(value: unknown, fields: Set<string>, seen: WeakSet<object>): unkno
     for (const [key, val] of Object.entries(value)) {
       if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
       const loweredKey = key.toLowerCase();
-      if (fields.has(loweredKey) || [...fields].some((f) => loweredKey.endsWith(f))) {
+      if (suffixes.some((suffix) => loweredKey.endsWith(suffix))) {
         out[key] = val === null || val === undefined ? val : REDACTED_PLACEHOLDER;
       } else {
-        out[key] = walk(val, fields, seen);
+        out[key] = walk(val, suffixes, seen);
       }
     }
     return out;

--- a/src/utils/redactSensitive.ts
+++ b/src/utils/redactSensitive.ts
@@ -66,7 +66,8 @@ function walk(value: unknown, fields: Set<string>, seen: WeakSet<object>): unkno
     const out: Record<string, unknown> = Object.create(null);
     for (const [key, val] of Object.entries(value)) {
       if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
-      if (fields.has(key.toLowerCase())) {
+      const loweredKey = key.toLowerCase();
+      if (fields.has(loweredKey) || [...fields].some((f) => loweredKey.endsWith(f))) {
         out[key] = val === null || val === undefined ? val : REDACTED_PLACEHOLDER;
       } else {
         out[key] = walk(val, fields, seen);


### PR DESCRIPTION
## Summary
- Follow-up to #38 (opt-in redaction). Related to #41.
- `redactSensitive()` matched field names by exact equality only. Dokploy's actual API responses prefix git-provider credential fields with the provider name (`githubClientSecret`, `githubPrivateKey`, `githubWebhookSecret`, and the `gitlab`/`bitbucket`/`gitea` equivalents), so none of them match the bare names in `DEFAULT_REDACTED_FIELDS` (`clientSecret`, `privateKey`, `secret`).
- Result: even with `DOKPLOY_REDACT_ENV=true`, `compose.one` (and any other endpoint returning a connected git provider) still returns the provider's client secret, private key, and webhook secret in plaintext.
- Fix: match a field name if it equals *or ends with* one of the configured redacted field names, so provider-prefixed variants are caught without needing to enumerate every provider explicitly. `DOKPLOY_REDACT_ENV`'s default is untouched (still opt-in, off by default) to avoid changing behavior for existing deployments.

## Test plan
- [x] `pnpm type-check`
- [x] `pnpm test` (25/25 passing)
- [x] Verified against a live `compose.one` response containing a real GitHub App `githubPrivateKey`/`githubClientSecret`/`githubWebhookSecret` — confirmed unredacted before this change, redacted after