### PR TITLE
fix: strip regex patterns invalid under strict provider validators

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -96,6 +96,40 @@ describe("MCP server tools/list", () => {
     }
   });
 
+  it("no tool inputSchema exposes patterns invalid under strict regex syntax", async () => {
+    const tools = await getToolList();
+
+    function findStrictInvalidPatterns(obj: unknown, path = ""): string[] {
+      if (obj === null || typeof obj !== "object") return [];
+      if (Array.isArray(obj)) {
+        return obj.flatMap((item, i) => findStrictInvalidPatterns(item, `${path}[${i}]`));
+      }
+
+      const record = obj as Record<string, unknown>;
+      const found: string[] = [];
+      for (const [key, value] of Object.entries(record)) {
+        const currentPath = path ? `${path}.${key}` : key;
+        if (key === "pattern" && typeof value === "string") {
+          try {
+            new RegExp(value, "v");
+          } catch {
+            found.push(`${currentPath}: ${value}`);
+          }
+        }
+        found.push(...findStrictInvalidPatterns(value, currentPath));
+      }
+      return found;
+    }
+
+    for (const tool of tools) {
+      const found = findStrictInvalidPatterns(tool.inputSchema);
+      expect(
+        found,
+        `Tool "${tool.name}" exposes provider-incompatible patterns at: ${found.join(", ")}`,
+      ).toHaveLength(0);
+    }
+  });
+
   it("all tools have name, inputSchema with type=object", async () => {
     const tools = await getToolList();
     for (const tool of tools) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,8 +51,20 @@ function stripNestedSchemaKeys(value: unknown): void {
   }
 }
 
+// Provider schema validators (OpenAI, Sonnet strict, DeepSeek) accept only a
+// conservative subset of ECMA-262: lookarounds and loosely-escaped character
+// classes (e.g. an unescaped "[" inside a class) are rejected even though JS
+// allows them. Lookarounds compile fine under the strict "v" flag, so they
+// need their own check; everything else is caught by the "v" compile test.
 function usesUnsupportedRegexSyntax(pattern: unknown): boolean {
-  return typeof pattern === "string" && /\(\?<?[=!]/.test(pattern);
+  if (typeof pattern !== "string") return false;
+  if (/\(\?<?[=!]/.test(pattern)) return true;
+  try {
+    new RegExp(pattern, "v");
+    return false;
+  } catch {
+    return true;
+  }
 }
 
 function stripUnsupportedRegexPatterns(value: unknown): void {


### PR DESCRIPTION
Fixes #43.

## Summary

Extends the runtime schema sanitization introduced in #58: in addition to lookarounds, any `pattern` that fails to compile under the strict RegExp `v` flag is now stripped from the tool schemas advertised via `tools/list`.

This fixes the database password pattern (`^[a-zA-Z0-9@#%^&*()_+\-=[\]{}|;:,.<>?~`]*$`) — its unescaped `[` inside the character class is valid classic ECMA-262 but rejected by DeepSeek and other strict provider validators, which broke all database tools (see #43).

## Why this approach

- Generic: catches any provider-incompatible pattern in any field, current or future — no hardcoded pattern strings or field-name allowlists.
- Single sanitization layer: reuses the exact mechanism from #58 in `server.ts`, instead of adding a second strip pass in the codegen path.
- Safe: server-side Zod validation is unchanged; only the JSON Schema exposed to clients loses the pattern.

## Verification

- All 15 tools affected by #43 (`libsql-*`, `mariadb-*`, `mongo-*`, `mysql-*`, `postgres-*`, `redis-changePassword`) verified clean in a real `tools/list` over InMemoryTransport.
- Sweep across all 546 tools: the only 2 surviving patterns (`^(all|\d+[smhd])$`, `^[a-zA-Z0-9.\-_]+$`) compile under strict syntax — nothing over-stripped.
- New regression test walks every tool schema and fails if any pattern doesn't compile with the `v` flag.
- `pnpm test` (6/6), `pnpm type-check`, `pnpm build` all pass.

Credit to @Baijack-star for the diagnosis in #43/#44 — this supersedes #44 with a generic runtime fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
