### PR TITLE
feat!: enable secret redaction in API responses by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ The configuration on Windows is slightly different compared to Linux or macOS. U
 | `DOKPLOY_TIMEOUT` | No | Request timeout in milliseconds (default: `30000`) |
 | `DOKPLOY_RETRY_ATTEMPTS` | No | Number of retry attempts (default: `3`) |
 | `DOKPLOY_RETRY_DELAY` | No | Delay between retries in milliseconds (default: `1000`) |
-| `DOKPLOY_REDACT_ENV` | No | When `true`, redacts secret-bearing fields from API responses before they reach the MCP client (default: `false`). Useful when an LLM consumes responses and you don't want env vars or compose files in its context. |
+| `DOKPLOY_REDACT_ENV` | No | Redacts secret-bearing fields (env vars, compose files, passwords, tokens, keys) from API responses before they reach the MCP client (default: `true`). Set to `false` only if you explicitly need raw secret values in LLM context. |
 | `DOKPLOY_REDACT_FIELDS` | No | Comma-separated list of response field names to redact when `DOKPLOY_REDACT_ENV=true`. Matched case-insensitively at any nesting depth. Defaults to: `env`, `buildArgs`, `composeFile`, `dockerCompose`, `environment`, `buildSecrets`, `previewBuildSecrets`, `password`, `currentPassword`, `appPassword`, `databasePassword`, `databaseRootPassword`, `redisPassword`, `mariadbPassword`, `mongoPassword`, `mysqlPassword`, `postgresPassword`, `registryPassword`, `token`, `accessToken`, `appToken`, `apiToken`, `botToken`, `refreshToken`, `secret`, `clientSecret`, `apiKey`, `secretAccessKey`, `accessKey`, `licenseKey`, `userKey`, `privateKey`, `privateKeyPass`, `encPrivateKey`, `encPrivateKeyPass`, `sshKey`, `sshPrivateKey`, `customGitSSHKey`, `dockerAuth`. |
 
 For Dokploy instances behind Cloudflare Access or a similar reverse proxy, pass service-token headers with placeholder values like this:

--- a/src/utils/clientConfig.test.ts
+++ b/src/utils/clientConfig.test.ts
@@ -58,3 +58,17 @@ describe("parseCustomHeaders", () => {
     );
   });
 });
+
+describe("getClientConfig", () => {
+  it("enables response redaction by default", async () => {
+    process.env.DOKPLOY_URL = "https://example.com";
+    process.env.DOKPLOY_API_KEY = "test-key";
+    delete process.env.DOKPLOY_REDACT_ENV;
+
+    const { getClientConfig } = await import("./clientConfig.js");
+    const config = getClientConfig();
+
+    expect(config.redactEnv).toBe(true);
+    expect(config.redactFields.length).toBeGreaterThan(0);
+  });
+});

--- a/src/utils/clientConfig.ts
+++ b/src/utils/clientConfig.ts
@@ -89,7 +89,7 @@ class ConfigManager {
       throw new Error("Environment variable DOKPLOY_API_KEY is not defined");
     }
 
-    const redactEnv = parseBoolean(process.env.DOKPLOY_REDACT_ENV, false);
+    const redactEnv = parseBoolean(process.env.DOKPLOY_REDACT_ENV, true);
     const parsedFields =
       process.env.DOKPLOY_REDACT_FIELDS?.split(",")
         .map((f) => f.trim())


### PR DESCRIPTION
Part of #65 (see also #26).

## Summary

Flips the default of `DOKPLOY_REDACT_ENV` from `false` to `true`: a default installation now redacts secret-bearing fields (env vars, compose files, passwords, tokens, keys) from API responses before they reach the MCP client, instead of silently sending them to LLM context and provider logs.

- Users who explicitly need raw secret values can opt out with `DOKPLOY_REDACT_ENV=false`.
- `DOKPLOY_REDACT_FIELDS` still customizes the field list.
- Adds a regression test asserting the secure default; README updated.

## Why

Secure-by-default: #65 and #26 both reported real secret leakage from default installs. The redaction capability existed but was opt-in, which means most deployments never enable it. Reading secrets back through an LLM is the niche case and should be the explicit opt-in, not the other way around.

**Note:** this is a behavior change — worth a minor version bump and a changelog mention. Together with #66 (suffix matching for provider-prefixed fields like `githubPrivateKey`), this fully addresses the MCP side of #65; the remaining ask (omitting secrets server-side) belongs to Dokploy core.

## Verification

- Full test suite: 34/34 across 3 files, plus type-check and build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)