### PR TITLE
chore: format redactSensitive.test.ts so precommit passes

### DIFF
--- a/src/utils/redactSensitive.test.ts
+++ b/src/utils/redactSensitive.test.ts
@@ -41,10 +41,7 @@ describe("redactSensitive", () => {
       apps: [{ name: "web", env: "SECRET=1" }, { config: { registryPassword: "p" } }],
     });
     expect(result).toEqual({
-      apps: [
-        { name: "web", env: "[REDACTED]" },
-        { config: { registryPassword: "[REDACTED]" } },
-      ],
+      apps: [{ name: "web", env: "[REDACTED]" }, { config: { registryPassword: "[REDACTED]" } }],
     });
   });
 


### PR DESCRIPTION
`pnpm precommit` (and `pnpm lint`) fail on a clean checkout of `main`: biome's formatter wants the expectation array in `src/utils/redactSensitive.test.ts` on one line. The wrapping came in with 081ec3c, and since no CI enforces the formatter, every contributor currently starts from a red precommit.

This is the output of `npx biome format --write src/utils/redactSensitive.test.ts` with the biome version from the lockfile. No semantic change; tests stay 46/46.

A small workflow running `pnpm precommit` and `pnpm test` on pull requests would keep formatter drift from landing again. I can send that as a follow-up PR if you want it.
