### PR TITLE
fix(server): emit numeric exclusive bounds for draft 2020-12 schemas

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -202,6 +202,39 @@ describe("MCP server tools/list", () => {
     }
   });
 
+  it("no tool inputSchema contains boolean exclusiveMinimum/exclusiveMaximum", async () => {
+    const tools = await getToolList();
+
+    function findBooleanExclusiveBounds(obj: unknown, path = ""): string[] {
+      if (obj === null || typeof obj !== "object") return [];
+      if (Array.isArray(obj)) {
+        return obj.flatMap((item, i) => findBooleanExclusiveBounds(item, `${path}[${i}]`));
+      }
+
+      const record = obj as Record<string, unknown>;
+      const found: string[] = [];
+      for (const [key, value] of Object.entries(record)) {
+        const currentPath = path ? `${path}.${key}` : key;
+        if (
+          (key === "exclusiveMinimum" || key === "exclusiveMaximum") &&
+          typeof value === "boolean"
+        ) {
+          found.push(currentPath);
+        }
+        found.push(...findBooleanExclusiveBounds(value, currentPath));
+      }
+      return found;
+    }
+
+    for (const tool of tools) {
+      const found = findBooleanExclusiveBounds(tool.inputSchema);
+      expect(
+        found,
+        `Tool "${tool.name}" has draft-4 boolean exclusive bounds at: ${found.join(", ")}`,
+      ).toHaveLength(0);
+    }
+  });
+
   it("all tools have name, inputSchema with type=object", async () => {
     const tools = await getToolList();
     for (const tool of tools) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -142,7 +142,12 @@ function stripUnsupportedRegexPatterns(value: unknown): void {
 // See https://github.com/Dokploy/mcp/issues/32
 function toDraft2020_12JsonSchema(schema: ZodObject<ZodRawShape>): Record<string, unknown> {
   const result = zodToJsonSchema(schema, {
-    target: "jsonSchema2019-09",
+    // zod-to-json-schema emits numeric exclusiveMinimum/exclusiveMaximum only
+    // for the jsonSchema7 target; every other target uses the draft-4 boolean
+    // form, which draft 2020-12 rejects. The targets are otherwise identical
+    // for these schemas, and $schema is replaced below anyway.
+    // See https://github.com/Dokploy/mcp/issues/74
+    target: "jsonSchema7",
     strictUnions: true,
   }) as Record<string, unknown>;
 


### PR DESCRIPTION
Fixes #74

## Root cause

`toDraft2020_12JsonSchema` converts with `zod-to-json-schema` using `target: "jsonSchema2019-09"`, then stamps the result as draft 2020-12. zod-to-json-schema emits the numeric `exclusiveMinimum`/`exclusiveMaximum` form only for the `jsonSchema7` target; every other target takes the non-draft-7 branch in `parsers/number.js` and emits the draft-4 pair:

```json
{"type": "integer", "exclusiveMinimum": true, "minimum": 0, "maximum": 9007199254740991}
```

Draft 2020-12 requires a number there, so strict validators reject the whole tool list the moment `dnsProvider-createRecord` or `dnsProvider-updateRecord` is in the payload, exactly as reported in #74.

## Fix

Switch the conversion target to `jsonSchema7`. To confirm this changes nothing else, I compared both targets across all 597 generated tools, ignoring the `$schema` key this function overwrites: the outputs are byte-identical except for the two affected tools, which now emit `"exclusiveMinimum": 0`.

## Verification

- New regression test sweeps every tool `inputSchema` for boolean exclusive bounds, following the existing nested-walk pattern from the #10/#32/#36/#37 tests. It fails against the previous target and passes with this change.
- Full suite: 46/46. `biome check` and `tsc --noEmit` clean on both changed files.

Note: `pnpm precommit` fails on a clean checkout of `main` for an unrelated pre-existing formatting issue in `redactSensitive.test.ts`; #75 fixes that separately.
