### PR TITLE
docs: correct DOKPLOY_REDACT_ENV default in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,9 @@ DOKPLOY_API_KEY=your-api-key-here
 # DOKPLOY_ENABLED_TAGS=project,application,postgres
 
 # Optional: Redact secret-bearing fields (env vars, build args, compose files)
-# from API responses before they reach the MCP client. Off by default.
-# DOKPLOY_REDACT_ENV=true
+# from API responses before they reach the MCP client. On by default;
+# set to false to receive unredacted responses.
+# DOKPLOY_REDACT_ENV=false
 # Optional: Override the default redacted field names (comma-separated).
 # Defaults: env, buildArgs, composeFile, dockerCompose, environment,
 #           buildSecrets, previewBuildSecrets,


### PR DESCRIPTION
The README already documents the default as true and clientConfig.ts reads it with parseBoolean(..., true), but .env.example still said "Off by default" and suggested setting it to true. Align the example with the actual behaviour so readers do not assume redaction is opt-in.


(cherry picked from commit de2cee800158e23dea8be803fb3784931a31cb86)