### PR TITLE
feat: allow disabling individual tools via DOKPLOY_DISABLED_TOOLS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ DOKPLOY_API_KEY=your-api-key-here
 # Optional: Filter which tool categories are loaded (comma-separated)
 # DOKPLOY_ENABLED_TAGS=project,application,postgres
 
+# Optional: Exclude individual tools by name (comma-separated). Applied last,
+# so a single tool can be dropped without losing the rest of its category.
+# DOKPLOY_DISABLED_TOOLS=docker-writeContainerFile,docker-deleteContainerFile
+
 # Optional: Redact secret-bearing fields (env vars, build args, compose files)
 # from API responses before they reach the MCP client. Off by default.
 # DOKPLOY_REDACT_ENV=true

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ The configuration on Windows is slightly different compared to Linux or macOS. U
 | `DOKPLOY_TOOL_PRESET` | No | Predefined toolset to load: `all` (default), `minimal`, `core`, `deploy`, `databases`, or `git`. Useful for clients/providers that struggle with very large tool lists. |
 | `DOKPLOY_ENABLED_TAGS` | No | Comma-separated list of tags to filter which tools are loaded (e.g., `project,application,postgres`) |
 | `DOKPLOY_DISABLED_TAGS` | No | Comma-separated list of tags to exclude from the selected toolset. Applied after `DOKPLOY_TOOL_PRESET` or `DOKPLOY_ENABLED_TAGS`. |
+| `DOKPLOY_DISABLED_TOOLS` | No | Comma-separated list of individual tool names to exclude (e.g. `docker-writeContainerFile,docker-deleteContainerFile`). Matched case-insensitively and applied last, so a single tool can be dropped without losing the rest of its tag. Unknown names are logged and ignored. |
 | `DOKPLOY_TIMEOUT` | No | Request timeout in milliseconds (default: `30000`) |
 | `DOKPLOY_RETRY_ATTEMPTS` | No | Number of retry attempts (default: `3`) |
 | `DOKPLOY_RETRY_DELAY` | No | Delay between retries in milliseconds (default: `1000`) |

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -19,7 +19,12 @@ function countByTags(tags: string[]): number {
 }
 
 describe("MCP server tools/list", () => {
-  const toolsetEnvVars = ["DOKPLOY_ENABLED_TAGS", "DOKPLOY_DISABLED_TAGS", "DOKPLOY_TOOL_PRESET"];
+  const toolsetEnvVars = [
+    "DOKPLOY_ENABLED_TAGS",
+    "DOKPLOY_DISABLED_TAGS",
+    "DOKPLOY_DISABLED_TOOLS",
+    "DOKPLOY_TOOL_PRESET",
+  ];
 
   afterEach(() => {
     for (const envVar of toolsetEnvVars) {
@@ -91,6 +96,50 @@ describe("MCP server tools/list", () => {
     );
     expect(tags.has("domain")).toBe(false);
     expect(tags.has("deployment")).toBe(false);
+  });
+
+  it("excludes individual tools named in DOKPLOY_DISABLED_TOOLS", async () => {
+    process.env.DOKPLOY_DISABLED_TOOLS = "docker-readContainerFile,docker-writeContainerFile";
+
+    const tools = await getToolList();
+    const names = new Set(tools.map((tool) => tool.name));
+
+    expect(tools).toHaveLength(generatedTools.length - 2);
+    expect(names.has("docker-readContainerFile")).toBe(false);
+    expect(names.has("docker-writeContainerFile")).toBe(false);
+    // The rest of the docker category survives — that is the point of
+    // disabling by tool name instead of by tag.
+    expect(names.has("docker-getContainers")).toBe(true);
+    expect(names.has("docker-restartContainer")).toBe(true);
+  });
+
+  it("matches DOKPLOY_DISABLED_TOOLS case-insensitively and ignores spacing", async () => {
+    process.env.DOKPLOY_DISABLED_TOOLS = " DOCKER-READCONTAINERFILE , ";
+
+    const tools = await getToolList();
+    const names = new Set(tools.map((tool) => tool.name));
+
+    expect(tools).toHaveLength(generatedTools.length - 1);
+    expect(names.has("docker-readContainerFile")).toBe(false);
+  });
+
+  it("ignores unknown names in DOKPLOY_DISABLED_TOOLS", async () => {
+    process.env.DOKPLOY_DISABLED_TOOLS = "does-notExist";
+
+    const tools = await getToolList();
+
+    expect(tools).toHaveLength(generatedTools.length);
+  });
+
+  it("applies DOKPLOY_DISABLED_TOOLS on top of a preset", async () => {
+    process.env.DOKPLOY_TOOL_PRESET = "minimal";
+    process.env.DOKPLOY_DISABLED_TOOLS = "project-remove";
+
+    const tools = await getToolList();
+    const names = new Set(tools.map((tool) => tool.name));
+
+    expect(tools).toHaveLength(countByTags(["project", "application"]) - 1);
+    expect(names.has("project-remove")).toBe(false);
   });
 
   it("falls back to all tools for an unknown preset", async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,22 @@ function parseTagList(value: string | undefined): Set<string> {
   );
 }
 
+/**
+ * Reports names in `DOKPLOY_DISABLED_TOOLS` that match no known tool. A typo
+ * would otherwise silently leave the tool enabled — the opposite of what an
+ * operator writing a deny-list intends.
+ */
+function warnAboutUnknownToolNames(disabledTools: Set<string>): void {
+  if (disabledTools.size === 0) return;
+
+  const knownNames = new Set(generatedTools.map((tool) => tool.name.toLowerCase()));
+  const unknown = [...disabledTools].filter((name) => !knownNames.has(name));
+
+  if (unknown.length > 0) {
+    logger.warn("Ignoring unknown entries in DOKPLOY_DISABLED_TOOLS", { unknown });
+  }
+}
+
 function isToolPreset(value: string): value is ToolPreset {
   return Object.hasOwn(TOOL_PRESETS, value);
 }
@@ -38,6 +54,7 @@ function isToolPreset(value: string): value is ToolPreset {
 function getEnabledTools() {
   const enabledTags = process.env.DOKPLOY_ENABLED_TAGS;
   const disabledTags = parseTagList(process.env.DOKPLOY_DISABLED_TAGS);
+  const disabledTools = parseTagList(process.env.DOKPLOY_DISABLED_TOOLS);
   const requestedPreset = process.env.DOKPLOY_TOOL_PRESET?.trim().toLowerCase() || "all";
   const preset: ToolPreset = isToolPreset(requestedPreset) ? requestedPreset : "all";
 
@@ -64,6 +81,13 @@ function getEnabledTools() {
     filtered = filtered.filter((tool) => !disabledTags.has(tool.tag.toLowerCase()));
   }
 
+  // Applied last, and by tool name rather than tag, so a single risky tool can
+  // be dropped without losing the rest of its category.
+  if (disabledTools.size > 0) {
+    warnAboutUnknownToolNames(disabledTools);
+    filtered = filtered.filter((tool) => !disabledTools.has(tool.name.toLowerCase()));
+  }
+
   const context = {
     total: generatedTools.length,
     loaded: filtered.length,
@@ -71,6 +95,7 @@ function getEnabledTools() {
     preset,
     enabledTags: [...selectedTags],
     disabledTags: [...disabledTags],
+    disabledTools: [...disabledTools],
   };
 
   logger.info("Loaded tools", context);


### PR DESCRIPTION
Tool filtering is currently tag-shaped only. Dropping one risky tool means dropping its whole category: excluding docker-writeContainerFile via DOKPLOY_DISABLED_TAGS costs all 18 docker tools, including harmless ones like docker-getContainers and docker-restartContainer.

Add a deny-list keyed by tool name, applied after the tag filters, so a single tool can be removed while its category stays available. Names are matched case-insensitively; unrecognised entries are logged rather than silently accepted, since a typo in a deny-list would otherwise leave the tool enabled.


(cherry picked from commit 398a958ce0cc6e768b4bb4eafd9be6c6f8fa387d)